### PR TITLE
Use kitchen logger to keep log files and color output

### DIFF
--- a/lib/kitchen/driver/dokken_version.rb
+++ b/lib/kitchen/driver/dokken_version.rb
@@ -19,6 +19,6 @@
 module Kitchen
   module Driver
     # Version string for Dokken Kitchen driver
-    DOKKEN_VERSION = '0.0.21'
+    DOKKEN_VERSION = '0.0.22'
   end
 end

--- a/lib/kitchen/provisioner/dokken.rb
+++ b/lib/kitchen/provisioner/dokken.rb
@@ -56,6 +56,7 @@ module Kitchen
         cmd << ' -j /opt/kitchen/dna.json'
         cmd << ' -l warn'
         cmd << ' -F doc'
+        cmd << ' --no-color'
       end
 
       def runner_container_name


### PR DESCRIPTION
Cool project! I saw Issue #3 and figured it was a good place to take a look around in a kitchen driver. The changes are, in order:
* Make it so the logger gets passed through
* Turn off coloring on the provisioner
* Use the logger append instead of print.