### PR TITLE
allow the log level to be specified in the provisioner configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -382,6 +382,22 @@ verifier:
   sudo: false
 ```
 
+
+### Chef Logging
+
+By default, the provisioner logs at `warn` level, meaning very little
+information is available for troubleshooting the Chef run. The logging level can
+ be overridden in the provisioner configuration:
+
+```
+provisioner:
+  name: dokken
+  log_level: debug
+```
+
+Available logging levels are: `auto`, `debug`, `info`, `warn`, `error`, and
+`fatal`.
+
 FAQ
 ===
 

--- a/lib/kitchen/provisioner/dokken.rb
+++ b/lib/kitchen/provisioner/dokken.rb
@@ -46,6 +46,10 @@ module Kitchen
         cleanup_sandbox
       end
 
+      def log_level
+        config[:log_level] || 'warn'
+      end
+
       private
 
       # magic method name because we're subclassing ChefZero
@@ -54,7 +58,7 @@ module Kitchen
         cmd << ' -z'
         cmd << ' -c /opt/kitchen/client.rb'
         cmd << ' -j /opt/kitchen/dna.json'
-        cmd << ' -l warn'
+        cmd << " -l #{log_level}"
         cmd << ' -F doc'
       end
 


### PR DESCRIPTION
I needed to get some troubleshooting information from the Chef run with kitchen-dokken, but the provisioner was set to log at warn level.

This PR makes it configurable (default is still warn).