### PR TITLE
Prevent collisions between docker-api and kitchen-docker

### DIFF
--- a/kitchen-dokken.gemspec
+++ b/kitchen-dokken.gemspec
@@ -19,5 +19,5 @@ Gem::Specification.new do |spec|
   spec.require_paths = ['lib']
 
   spec.add_dependency 'test-kitchen', '~> 1.5'
-  spec.add_dependency 'docker-api', '~> 1.26.2'
+  spec.add_dependency 'docker-api', '~> 1.28'
 end

--- a/lib/kitchen/driver/dokken/helpers.rb
+++ b/lib/kitchen/driver/dokken/helpers.rb
@@ -47,14 +47,14 @@ EOF
       end
 
       def create_data_image
-        return if Docker::Image.exist?(data_image)
+        return if ::Docker::Image.exist?(data_image)
 
         tmpdir = Dir.tmpdir
         FileUtils.mkdir_p "#{tmpdir}/dokken"
         File.write("#{tmpdir}/dokken/Dockerfile", data_dockerfile)
         File.write("#{tmpdir}/dokken/authorized_keys", insecure_ssh_public_key)
 
-        i = Docker::Image.build_from_dir("#{tmpdir}/dokken", { 'nocache' => true, 'rm' => true })
+        i = ::Docker::Image.build_from_dir("#{tmpdir}/dokken", { 'nocache' => true, 'rm' => true })
         i.tag('repo' => repo(data_image), 'tag' => tag(data_image), 'force' => true)
       end
     end

--- a/lib/kitchen/transport/dokken.rb
+++ b/lib/kitchen/transport/dokken.rb
@@ -56,13 +56,13 @@ module Kitchen
       # @author Sean OMeara <sean@chef.io>
       class Connection < Kitchen::Transport::Dokken::Connection
         def docker_connection
-          @docker_connection ||= Docker::Connection.new(options[:docker_host_url], options[:docker_host_options])
+          @docker_connection ||= ::Docker::Connection.new(options[:docker_host_url], options[:docker_host_options])
         end
 
         def execute(command)
           return if command.nil?
 
-          with_retries { @runner = Docker::Container.get(instance_name, {}, docker_connection) }
+          with_retries { @runner = ::Docker::Container.get(instance_name, {}, docker_connection) }
           with_retries do
             o = @runner.exec(Shellwords.shellwords(command)) { |_stream, chunk| print "#{chunk}" }
             @exit_code = o[2]
@@ -76,7 +76,7 @@ module Kitchen
           # Disabling this for now.. the Docker ZFS driver won't let us
           # commit running containers.
           #
-          # with_retries { @old_image = Docker::Image.get(work_image, {}, docker_connection) }
+          # with_retries { @old_image = ::Docker::Image.get(work_image, {}, docker_connection) }
           # with_retries { @new_image = @runner.commit }
           # with_retries { @new_image.tag('repo' => work_image, 'tag' => 'latest', 'force' => 'true') }
           # with_retries { @old_image.remove }
@@ -140,10 +140,10 @@ module Kitchen
           begin
             block.call
             # Only catch errors that can be fixed with retries.
-          rescue Docker::Error::ServerError, # 404
-                 Docker::Error::UnexpectedResponseError, # 400
-                 Docker::Error::TimeoutError,
-                 Docker::Error::IOError => e
+          rescue ::Docker::Error::ServerError, # 404
+                 ::Docker::Error::UnexpectedResponseError, # 400
+                 ::Docker::Error::TimeoutError,
+                 ::Docker::Error::IOError => e
             tries -= 1
             retry if tries > 0
             raise e
@@ -162,7 +162,7 @@ module Kitchen
       def connection_options(data) # rubocop:disable Metrics/MethodLength
         opts = {}
         opts[:docker_host_url] = config[:docker_host_url]
-        opts[:docker_host_options] = Docker.options
+        opts[:docker_host_options] = ::Docker.options
         opts[:data_container] = data[:data_container]
         opts[:instance_name] = data[:instance_name]
         opts


### PR DESCRIPTION
It's probably a weird edge case that only applies to me, I'm sure, but having a config with both this driver and kitchen-docker loaded right now results in a bunch of this:

```
>>>>>> Message: Failed to complete #destroy action: [uninitialized constant Kitchen::Driver::Docker::Error
```

This would rectify that and also bump the docker-api dep. The current 1.26.2 conflicts with the 1.28.0 pin in the [docker cookbook](https://github.com/chef-cookbooks/docker/blob/master/libraries/_autoload.rb#L2). I don't know the history of the gem, though, so maybe it would be better set as `~> 1.28.0` or needs to be left unchanged for specific reasons?

Thanks!