### PR TITLE
Set the chef log level to be the same as for the kitchen run.

### DIFF
--- a/lib/kitchen/provisioner/dokken.rb
+++ b/lib/kitchen/provisioner/dokken.rb
@@ -54,7 +54,7 @@ module Kitchen
         cmd << ' -z'
         cmd << ' -c /opt/kitchen/client.rb'
         cmd << ' -j /opt/kitchen/dna.json'
-        cmd << ' -l warn'
+        cmd << " -l #{Util.from_logger_level(logger.level)}"
         cmd << ' -F doc'
       end
 


### PR DESCRIPTION
This duplicates the behavior of the kitchen-docker module.