### PR TITLE
Use data container's IP if unix socket and SSH port is mapped to 0.0.0.0

### DIFF
--- a/lib/kitchen/transport/dokken.rb
+++ b/lib/kitchen/transport/dokken.rb
@@ -84,19 +84,24 @@ module Kitchen
         end
 
         def upload(locals, remote)
+          port = options[:data_container][:NetworkSettings][:Ports][:"22/tcp"][0][:HostPort]
+
           if options[:host_ip_override]
             # Allow connecting to any ip/hostname to support sibling containers
             ip = options[:host_ip_override]
           elsif options[:docker_host_url] =~ /unix:/
-            # we should read the proper mapped ip, since this allows us to upload the files
-            ip = options[:data_container][:NetworkSettings][:Ports][:"22/tcp"][0][:HostIp]
+            if options[:data_container][:NetworkSettings][:Ports][:"22/tcp"][0][:HostIp] = '0.0.0.0'
+              ip = options[:data_container][:NetworkSettings][:IPAddress]
+              port = '22'
+            else
+              # we should read the proper mapped ip, since this allows us to upload the files
+              ip = options[:data_container][:NetworkSettings][:Ports][:"22/tcp"][0][:HostIp]
+            end
           elsif options[:docker_host_url] =~ /tcp:/
             ip = options[:docker_host_url].split('tcp://')[1].split(':')[0]
           else
             raise Kitchen::UserError, 'docker_host_url must be tcp:// or unix://'
           end
-
-          port = options[:data_container][:NetworkSettings][:Ports][:"22/tcp"][0][:HostPort]
 
           tmpdir = Dir.tmpdir
           FileUtils.mkdir_p "#{tmpdir}/dokken"


### PR DESCRIPTION
I'm trying to use kitchen-dokken in GitLab CI with docker-based runners, but cookbooks are failing to sync:

```
$ kitchen test
-----> Starting Kitchen (v1.13.2)
-----> Cleaning up any prior instances of <default-centos-7>
-----> Destroying <default-centos-7>...
       Finished destroying <default-centos-7> (0m1.30s).
-----> Testing <default-centos-7>
-----> Creating <default-centos-7>...
       Finished creating <default-centos-7> (0m3.92s).
-----> Converging <default-centos-7>...
       Preparing files for transfer
       Preparing dna.json
       Resolving cookbook dependencies with Berkshelf 5.2.0...
       Removing non-cookbook files before transfer
       Preparing validation.pem
       Preparing client.rb
       Transferring files to <default-centos-7>
ssh: connect to host 0.0.0.0 port 32772: Connection refused

rsync: connection unexpectedly closed (0 bytes received so far) [sender]
rsync error: unexplained error (code 255) at io.c(226) [sender=3.1.1]
```

GitLab CI is configured to map `/var/run/docker.sock:/var/run/docker.sock` from the host into its runner container, and then again from the runner container to the container running kitchen. This change will use the data container's IP address and port 22 for sync if the port is mapped to all interfaces.

On that note, what is the reason in https://github.com/someara/kitchen-dokken/blob/master/lib/kitchen/transport/dokken.rb#L92 we are getting the IP the port is mapped to rather than connecting to the data container directly?