### PR TITLE
When config[:hostname] is applied to a suite, this should be the name…

### DIFF
--- a/lib/kitchen/driver/dokken.rb
+++ b/lib/kitchen/driver/dokken.rb
@@ -151,8 +151,12 @@ module Kitchen
       end
 
       def instance_name
-        prefix = (Digest::SHA2.hexdigest FileUtils.pwd)[0,10]
-        "#{prefix}-#{instance.name}"
+        if config[:hostname]
+          config[:hostname]
+        else
+          prefix = (Digest::SHA2.hexdigest FileUtils.pwd)[0,10]
+          "#{prefix}-#{instance.name}"
+        end
       end
 
       def delete_chef_container


### PR DESCRIPTION
… of the container. This makes it possible to use docker DNS to manage connectivity between test suites( e.g. a webserver and a database)

Not sure why the prefix is put there in the first place (SHA sum or not), so not sure if this breaks anything important. Tested internally and seems to allow links: to work properly again.