### PR TITLE
Add compatibility with Windows

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,5 +1,5 @@
 source 'https://rubygems.org'
 
-gem 'kitchen-dokken'
-gem 'test-kitchen'
+gemspec
+
 gem 'librarian-chef-nochef', '~> 0.2'

--- a/lib/kitchen/driver/dokken/helpers.rb
+++ b/lib/kitchen/driver/dokken/helpers.rb
@@ -57,6 +57,19 @@ EOF
         i = ::Docker::Image.build_from_dir("#{tmpdir}/dokken", 'nocache' => true, 'rm' => true)
         i.tag('repo' => repo(data_image), 'tag' => tag(data_image), 'force' => true)
       end
+
+      def default_docker_host
+        if ENV['DOCKER_HOST']
+          ENV['DOCKER_HOST']
+        elsif File.exist?('/var/run/docker.sock')
+          'unix:///var/run/docker.sock'
+        # TODO: Docker for Windows also operates over a named pipe at
+        # //./pipe/docker_engine that can be used if named pipe support is
+        # added to the docker-api gem.
+        else
+          'tcp://127.0.0.1:2375'
+        end
+      end
     end
   end
 end

--- a/lib/kitchen/transport/dokken.rb
+++ b/lib/kitchen/transport/dokken.rb
@@ -16,6 +16,7 @@
 # limitations under the License.
 
 require 'kitchen'
+require 'net/scp'
 require 'tmpdir'
 require 'digest/sha1'
 require_relative 'dokken/helpers'
@@ -38,11 +39,11 @@ module Kitchen
 
       plugin_version Kitchen::VERSION
 
-      default_config :docker_host_url, ENV['DOCKER_HOST'] || 'unix:///var/run/docker.sock'
+      default_config :docker_host_url, default_docker_host
       default_config :read_timeout, 3600
       default_config :write_timeout, 3600
       default_config :host_ip_override do |transport|
-        transport.docker_for_mac? ? "localhost" : false
+        transport.docker_for_mac_or_win? ? "localhost" : false
       end
 
       # (see Base#connection)
@@ -110,20 +111,32 @@ module Kitchen
           File.write("#{tmpdir}/dokken/id_rsa", insecure_ssh_private_key)
           FileUtils.chmod(0600, "#{tmpdir}/dokken/id_rsa")
 
-          rsync_cmd = '/usr/bin/rsync -a -e'
-          rsync_cmd << ' \''
-          rsync_cmd << 'ssh -2'
-          rsync_cmd << " -i #{tmpdir}/dokken/id_rsa"
-          rsync_cmd << ' -o CheckHostIP=no'
-          rsync_cmd << ' -o Compression=no'
-          rsync_cmd << ' -o PasswordAuthentication=no'
-          rsync_cmd << ' -o StrictHostKeyChecking=no'
-          rsync_cmd << ' -o UserKnownHostsFile=/dev/null'
-          rsync_cmd << ' -o LogLevel=ERROR'
-          rsync_cmd << " -p #{port}"
-          rsync_cmd << '\''
-          rsync_cmd << " #{locals.join(' ')} root@#{ip}:#{remote}"
-          system(rsync_cmd)
+          begin
+            rsync_cmd = '/usr/bin/rsync -a -e'
+            rsync_cmd << ' \''
+            rsync_cmd << 'ssh -2'
+            rsync_cmd << " -i #{tmpdir}/dokken/id_rsa"
+            rsync_cmd << ' -o CheckHostIP=no'
+            rsync_cmd << ' -o Compression=no'
+            rsync_cmd << ' -o PasswordAuthentication=no'
+            rsync_cmd << ' -o StrictHostKeyChecking=no'
+            rsync_cmd << ' -o UserKnownHostsFile=/dev/null'
+            rsync_cmd << ' -o LogLevel=ERROR'
+            rsync_cmd << " -p #{port}"
+            rsync_cmd << '\''
+            rsync_cmd << " #{locals.join(' ')} root@#{ip}:#{remote}"
+            %x(#{rsync_cmd})
+          rescue Errno::ENOENT
+            debug 'Rsync is not installed. Falling back to SCP.'
+            locals.each do |local|
+              Net::SCP.upload!(ip,
+                               'root',
+                               local,
+                               remote,
+                               recursive: true,
+                               ssh: { port: port, keys: ["#{tmpdir}/dokken/id_rsa"] })
+            end
+          end
         end
 
         def login_command
@@ -163,11 +176,11 @@ module Kitchen
         end
       end
 
-      # Detect whether or not we are running in Docker for Mac
+      # Detect whether or not we are running in Docker for Mac or Windows
       #
       # @return [TrueClass,FalseClass]
-      def docker_for_mac?
-        Docker.info["Name"] == "moby"
+      def docker_for_mac_or_win?
+        ::Docker.info(::Docker::Connection.new(config[:docker_host_url], {}))['Name'] == "moby"
       end
 
       private


### PR DESCRIPTION
* Adjust method calls where docker_connection was being sent as the second instead of third argument
* Fall back to a TCP connection if no unix socket is present
* Fall back to SCP if Rsync isn't installed
* Pass around the Dockerfile as a string instead of a file (to get
  around issues with Dir.mktmpdir on Windows not always cleaning up
  correctly)

With these changes, the included test configs now pass in Windows as well as Linux and MacOS.

There are still some issues when used with Inspec, but those don't appear to be caused by anything in this driver.