### PR TITLE
Pass along ENV variables in the provisioner

### DIFF
--- a/lib/kitchen/provisioner/dokken.rb
+++ b/lib/kitchen/provisioner/dokken.rb
@@ -50,7 +50,9 @@ module Kitchen
 
       # magic method name because we're subclassing ChefZero
       def run_command
-        cmd = '/opt/chef/embedded/bin/chef-client'
+        cmd = 'TEST_KITCHEN=1'
+        cmd << ' CI=1' if ENV['CI']
+        cmd << ' /opt/chef/embedded/bin/chef-client'
         cmd << ' -z'
         cmd << ' -c /opt/kitchen/client.rb'
         cmd << ' -j /opt/kitchen/dna.json'


### PR DESCRIPTION
A feature I've been using since it's inclusion is Test Kitchen passing along the `TEST_KITCHEN` environment variable along which lets me execute some cookbook code meant for testing. This lets my tests live along side the running code and has proven to be useful. However, since dokken uses a very different provisioner implementation, this is a quick update to get it to pass along environment variables to the executing chef run. 

I do wonder if this could be improved by using the already built-in helpers in TK because [this is where I gleaned this trick from](https://github.com/test-kitchen/test-kitchen/blob/f8f87b8df62ce53aecfb6a1af977fc74daeaa0df/lib/kitchen/configurable.rb#L311-L317) in the configurable section.