### PR TITLE
workaround for excon EOF error

### DIFF
--- a/lib/kitchen/transport/dokken.rb
+++ b/lib/kitchen/transport/dokken.rb
@@ -181,6 +181,12 @@ module Kitchen
       # @return [TrueClass,FalseClass]
       def docker_for_mac_or_win?
         ::Docker.info(::Docker::Connection.new(config[:docker_host_url], {}))['Name'] == "moby"
+      rescue
+        # looks like with recent docker versions the request above throws
+        # Excon::Error::Socket: end of file reached (EOFError)
+        # when connection is made over tcp/https using Excon.
+        #
+        false
       end
 
       private


### PR DESCRIPTION
When running against a remote docker api (1.13.0 tested) using "tcp" (https), excon, the http backend of the `docker-api` gem explodes.

Error:

```
D      ------Exception-------
D      Class: Kitchen::ActionFailed
D      Message: 1 actions failed.
>>>>>>     Failed to complete #converge action: [end of file reached (EOFError)] on dokken-default-chef12-debian
D      ----------------------
D      ------Backtrace-------
```


```ruby

[5] pry(#<Kitchen::Transport::Dokken>)> config
=> {:name=>"dokken",
 :kitchen_root=>"/Users/rmoriz/project/chef/devops-project-base",
 :test_base_path=>"/Users/rmoriz/project/chef/devops-project-base/test/integration",
 :log_level=>:debug,
 :docker_host_url=>"tcp://10.0.1.49:2376",
 :read_timeout=>3600,
 :write_timeout=>3600,
 :host_ip_override=>#<Proc:0x007fbe64e8ab28@/Users/rmoriz/project/projects/kitchen-dokken/lib/kitchen/transport/dokken.rb:45>}
[6] pry(#<Kitchen::Transport::Dokken>)> config.class
=> Kitchen::LazyHash
[7] pry(#<Kitchen::Transport::Dokken>)> config.to_hash
Excon::Error::Socket: end of file reached (EOFError)
from <internal:prelude>:76:in `__read_nonblock'
```

caused by:

```ruby
irb(main):017:0> Docker.info(::Docker::Connection.new('tcp://10.0.1.49:2376', {}))
Excon::Error::Socket: end of file reached (EOFError)
	from <internal:prelude>:76:in `__read_nonblock'
	from <internal:prelude>:76:in `read_nonblock'
	from /Users/rmoriz/.rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/excon-0.54.0/lib/excon/socket.rb:46:in `readline'
	from /Users/rmoriz/.rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/excon-0.54.0/lib/excon/response.rb:179:in `parse_headers'
	from /Users/rmoriz/.rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/excon-0.54.0/lib/excon/response.rb:89:in `parse'
	from /Users/rmoriz/.rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/excon-0.54.0/lib/excon/middlewares/response_parser.rb:7:in `response_call'
	from /Users/rmoriz/.rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/docker-api-1.33.1/lib/excon/middlewares/hijack.rb:45:in `response_call'
	from /Users/rmoriz/.rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/excon-0.54.0/lib/excon/connection.rb:388:in `response'
	from /Users/rmoriz/.rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/excon-0.54.0/lib/excon/connection.rb:252:in `request'
	from /Users/rmoriz/.rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/excon-0.54.0/lib/excon/middlewares/idempotent.rb:27:in `error_call'
	from /Users/rmoriz/.rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/excon-0.54.0/lib/excon/middlewares/base.rb:11:in `error_call'
	from /Users/rmoriz/.rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/excon-0.54.0/lib/excon/middlewares/base.rb:11:in `error_call'
	from /Users/rmoriz/.rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/excon-0.54.0/lib/excon/middlewares/base.rb:11:in `error_call'
	from /Users/rmoriz/.rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/excon-0.54.0/lib/excon/connection.rb:272:in `rescue in request'
	from /Users/rmoriz/.rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/excon-0.54.0/lib/excon/connection.rb:215:in `request'
	from /Users/rmoriz/.rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/excon-0.54.0/lib/excon/middlewares/idempotent.rb:27:in `error_call'
	from /Users/rmoriz/.rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/excon-0.54.0/lib/excon/middlewares/base.rb:11:in `error_call'
	from /Users/rmoriz/.rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/excon-0.54.0/lib/excon/middlewares/base.rb:11:in `error_call'
	from /Users/rmoriz/.rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/excon-0.54.0/lib/excon/middlewares/base.rb:11:in `error_call'
	from /Users/rmoriz/.rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/excon-0.54.0/lib/excon/connection.rb:272:in `rescue in request'
	from /Users/rmoriz/.rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/excon-0.54.0/lib/excon/connection.rb:215:in `request'
	from /Users/rmoriz/.rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/excon-0.54.0/lib/excon/middlewares/idempotent.rb:27:in `error_call'
	from /Users/rmoriz/.rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/excon-0.54.0/lib/excon/middlewares/base.rb:11:in `error_call'
	from /Users/rmoriz/.rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/excon-0.54.0/lib/excon/middlewares/base.rb:11:in `error_call'
	from /Users/rmoriz/.rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/excon-0.54.0/lib/excon/middlewares/base.rb:11:in `error_call'
	from /Users/rmoriz/.rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/excon-0.54.0/lib/excon/connection.rb:272:in `rescue in request'
	from /Users/rmoriz/.rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/excon-0.54.0/lib/excon/connection.rb:215:in `request'
	from /Users/rmoriz/.rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/docker-api-1.33.1/lib/docker/connection.rb:40:in `request'
	from /Users/rmoriz/.rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/docker-api-1.33.1/lib/docker/connection.rb:65:in `block (2 levels) in <class:Connection>'
	from /Users/rmoriz/.rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/docker-api-1.33.1/lib/docker.rb:114:in `info'
	from (irb):17
	from /Users/rmoriz/.rbenv/versions/2.3.1/bin/irb:11:in `<main>'
```






