### PR TITLE
allow the use of a port number in the image's repo url

### DIFF
--- a/lib/kitchen/driver/dokken.rb
+++ b/lib/kitchen/driver/dokken.rb
@@ -319,9 +319,23 @@ module Kitchen
       rescue
         false
       end
+      
+      def parse_image_name(image)
+        parts = image.split(':')
+
+        if parts.size > 2
+          tag = parts.pop
+          repo = parts.join(':')
+        else
+          tag = parts[1] || 'latest'
+          repo = parts[0]
+        end
+        
+        [repo, tag]
+      end
 
       def repo(image)
-        image.split(':')[0]
+        parse_image_name(image)[0]
       end
 
       def create_container(args)
@@ -377,7 +391,7 @@ module Kitchen
       end
 
       def tag(image)
-        image.split(':')[1] || 'latest'
+        parse_image_name(image)[1]
       end
 
       def chef_container_name


### PR DESCRIPTION
This is useful for enterprises that have their own private docker registries using a non-default port. For example, if my registry lives at `my.awesome.docker.registry:8081` and my image is at `ubuntu/xenial` I would then be able to set my image to `my.awesome.docker.registry:8081/ubuntu/ubuntu:xenial` in the `.kitchen.yaml`.

This makes it so you must use a tag if you want to use a port. Otherwise anything after the colon gets interpreted as the tag. This also preserves the default behavior of defaulting to tag `latest` when a port is not passed. Here are the valid uses with this method:

```
image: ubuntu/ubuntu
image: ubuntu/ubuntu:latest
image: my.awesome.docker.registry:8081/ubuntu/ubuntu:latest
```
in other words:
```
image: repo_without_port
image: repo_without_port:tag
image: repo_with_port:tag
```