### PR TITLE
Use generic chef-client binary

### DIFF
--- a/lib/kitchen/provisioner/dokken.rb
+++ b/lib/kitchen/provisioner/dokken.rb
@@ -48,7 +48,7 @@ module Kitchen
 
       # patching Kitchen::Provisioner::ChefZero#run_command
       def run_command
-        cmd = '/opt/chef/embedded/bin/chef-client'
+        cmd = '/opt/chef/bin/chef-client'
         cmd << ' -z'
         cmd << ' -c /opt/kitchen/client.rb'
         cmd << ' -j /opt/kitchen/dna.json'


### PR DESCRIPTION
Use generic `/opt/chef/bin/chef-client` to be backwards compatible up to chef version 10

Fixes #66 