### PR TITLE
provide several options to have more control over the provisioner

### DIFF
--- a/README.md
+++ b/README.md
@@ -389,6 +389,20 @@ Chef publishes all functioning builds to the [Docker Hub](https://hub.docker.com
 including those from the "current" channel. If you wish to use pre-release versions of Chef, set
 your `chef_version` value to "current".
 
+
+### Chef options
+
+It is possible to pass several extra configs to configure the chef binary and options, for example
+ to use older versions that do not have the "-z" switch or to get some debug logging.
+
+```
+provisioner:
+  chef_binary: /opt/chef/bin/chef-solo
+  chef_options: ""
+  chef_log_level: debug
+  chef_output_format: minimal
+```
+
 FAQ
 ===
 

--- a/lib/kitchen/provisioner/dokken.rb
+++ b/lib/kitchen/provisioner/dokken.rb
@@ -31,6 +31,10 @@ module Kitchen
       plugin_version Kitchen::VERSION
 
       default_config :root_path, '/opt/kitchen'
+      default_config :chef_binary, '/opt/chef/embedded/bin/chef-client'
+      default_config :chef_options, ' -z'
+      default_config :chef_log_level, 'warn'
+      default_config :chef_output_format, 'doc'
 
       # (see Base#call)
       def call(state)
@@ -44,16 +48,39 @@ module Kitchen
         #   cleanup_sandbox
       end
 
+      def validate_config
+        # check if we have an space for the user provided options
+        # or add it if not to avoid issues
+        unless config[:chef_options].start_with? ' '
+          config[:chef_options].prepend(' ')
+        end
+
+        # strip spaces from all other options
+        config[:chef_binary] = config[:chef_binary].strip
+        config[:chef_log_level] = config[:chef_log_level].strip
+        config[:chef_output_format] = config[:chef_output_format].strip
+
+        # if the user wants to be funny and pass empty strings
+        # just use the defaults
+        if config[:chef_log_level].empty?
+          config[:chef_log_level] = 'warn'
+        end
+        if config[:chef_output_format].empty?
+          config[:chef_output_format] = 'doc'
+        end
+      end
+
       private
 
       # patching Kitchen::Provisioner::ChefZero#run_command
       def run_command
-        cmd = '/opt/chef/embedded/bin/chef-client'
-        cmd << ' -z'
+        validate_config
+        cmd = config[:chef_binary]
+        cmd << config[:chef_options].to_s
+        cmd << " -l #{config[:chef_log_level]}"
+        cmd << " -F #{config[:chef_output_format]}"
         cmd << ' -c /opt/kitchen/client.rb'
         cmd << ' -j /opt/kitchen/dna.json'
-        cmd << ' -l warn'
-        cmd << ' -F doc'
       end
 
       def runner_container_name


### PR DESCRIPTION
Provides 4 new options to have more control over the provisioner:

chef_binary: Allows to provide a path for the chef-{client, solo, zero} binary to allow
control over what binary to launch
chef_options: Allows to pass extra options to the chef binary call or avoid the default -z option
chef_log_level: Allows to pass the log level for the chef run
chef_output_format: Allows to set the format of the chef output


This also provides a fix for #66 