### PR TITLE
Added user to the temporary path for generating keys

### DIFF
--- a/lib/kitchen/transport/dokken.rb
+++ b/lib/kitchen/transport/dokken.rb
@@ -97,7 +97,7 @@ module Kitchen
 
           tmpdir = Dir.tmpdir + '/dokken/'
           FileUtils.mkdir_p "#{tmpdir}", :mode => 0777
-          tmpdir += %x{whoami}.strip
+          tmpdir += Process.uid.to_s
           FileUtils.mkdir_p "#{tmpdir}"
           File.write("#{tmpdir}/id_rsa", insecure_ssh_private_key)
           FileUtils.chmod(0600, "#{tmpdir}/id_rsa")
@@ -125,7 +125,7 @@ module Kitchen
                                local,
                                remote,
                                recursive: true,
-                               ssh: { port: port, keys: ["#{tmpdir}/dokken/id_rsa"] })
+                               ssh: { port: port, keys: ["#{tmpdir}/id_rsa"] })
             end
           end
         end

--- a/lib/kitchen/transport/dokken.rb
+++ b/lib/kitchen/transport/dokken.rb
@@ -18,6 +18,7 @@
 require 'kitchen'
 require 'net/scp'
 require 'tmpdir'
+require 'etc'
 require 'digest/sha1'
 require_relative '../helpers'
 
@@ -95,16 +96,16 @@ module Kitchen
             raise Kitchen::UserError, 'docker_host_url must be tcp:// or unix://'
           end
 
-          tmpdir = Dir.tmpdir
-          FileUtils.mkdir_p "#{tmpdir}/dokken"
-          File.write("#{tmpdir}/dokken/id_rsa", insecure_ssh_private_key)
-          FileUtils.chmod(0600, "#{tmpdir}/dokken/id_rsa")
+          tmpdir = Dir.tmpdir + "/dokken/" + Etc.getlogin
+          FileUtils.mkdir_p "#{tmpdir}"
+          File.write("#{tmpdir}/id_rsa", insecure_ssh_private_key)
+          FileUtils.chmod(0600, "#{tmpdir}/id_rsa")
 
           begin
             rsync_cmd = '/usr/bin/rsync -a -e'
             rsync_cmd << ' \''
             rsync_cmd << 'ssh -2'
-            rsync_cmd << " -i #{tmpdir}/dokken/id_rsa"
+            rsync_cmd << " -i #{tmpdir}/id_rsa"
             rsync_cmd << ' -o CheckHostIP=no'
             rsync_cmd << ' -o Compression=no'
             rsync_cmd << ' -o PasswordAuthentication=no'

--- a/lib/kitchen/transport/dokken.rb
+++ b/lib/kitchen/transport/dokken.rb
@@ -18,7 +18,6 @@
 require 'kitchen'
 require 'net/scp'
 require 'tmpdir'
-require 'etc'
 require 'digest/sha1'
 require_relative '../helpers'
 
@@ -96,7 +95,9 @@ module Kitchen
             raise Kitchen::UserError, 'docker_host_url must be tcp:// or unix://'
           end
 
-          tmpdir = Dir.tmpdir + "/dokken/" + Etc.getlogin
+          tmpdir = Dir.tmpdir + '/dokken/'
+          FileUtils.mkdir_p "#{tmpdir}", :mode => 0777
+          tmpdir += %x{whoami}.strip
           FileUtils.mkdir_p "#{tmpdir}"
           File.write("#{tmpdir}/id_rsa", insecure_ssh_private_key)
           FileUtils.chmod(0600, "#{tmpdir}/id_rsa")


### PR DESCRIPTION
As described in https://github.com/someara/kitchen-dokken/issues/70 the `tmpdir` is shared between users. As the file created is set to be only  [modifiable by the owner](https://github.com/someara/kitchen-dokken/compare/master...edupo:fix/non-shared-tmp?expand=1#diff-e50af27eed3b0cc25806cd3c08774f5fL101) this leads to problems when more than one user is using this specific driver on the same computer.