### PR TITLE
mount default boot2docker shared folder in Windows

### DIFF
--- a/lib/kitchen/helpers.rb
+++ b/lib/kitchen/helpers.rb
@@ -114,12 +114,22 @@ EOF
       end
     end
 
+    def home_dir
+      # while dokken_binds avoid invalid bind mount spec "C:/Users/..." error by
+      # remote docker host virtual box shared folder on boot2docker created by docker-machine in Windows
+      # refs:
+      # https://github.com/docker/machine/issues/1814
+      # https://github.com/docker/toolbox/issues/607
+      return Dir.home.sub 'C:/Users', '/c/Users' if (Dir.home =~ /^C:/ and remote_docker_host?)
+      Dir.home
+    end
+
     def dokken_kitchen_sandbox
-      "#{Dir.home}/.dokken/kitchen_sandbox/#{instance_name}"
+      "#{home_dir}/.dokken/kitchen_sandbox/#{instance_name}"
     end
 
     def dokken_verifier_sandbox
-      "#{Dir.home}/.dokken/verifier_sandbox/#{instance_name}"
+      "#{home_dir}/.dokken/verifier_sandbox/#{instance_name}"
     end
 
     def instance_name


### PR DESCRIPTION
This PR will fix https://github.com/someara/kitchen-dokken/issues/84 by instructing dokken driver to mount default boot2docker share folder when docker remote host is created by docker-machine in Windows instead of instructing mount local directory.

Related with https://github.com/docker/machine/issues/1814 and https://github.com/docker/toolbox/issues/607