### PR TITLE
3) readme: systemd requires specific mount

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,7 +108,7 @@ from `chef-<version>` and `<suite-name>-data`, giving access to Chef
 and the test data. By default, the `pid_one_command` of the runner
 container is a script that sleeps in a loop, letting us `exec` our
 provisioner in the next phase. It can be overridden with init systems
-like Upstart and Systemd, for testing recipes with service resources
+like Upstart and systemd, for testing recipes with service resources
 as needed.
 
 - List containers
@@ -343,10 +343,10 @@ testing recipes that use the `service` resource.
 
 The default `pid_one_command` is `'sh -c "trap exit 0 SIGTERM; while :; do sleep 1; done"'`
 
-If you need to use the service resource to drive Upstart or Systemd, you'll need to
+If you need to use the service resource to drive Upstart or systemd, you'll need to
 specify the path to init. Here are more examples from `httpd`
 
-- Systemd for RHEL-7 based platforms
+- systemd for RHEL-7 based platforms
 ```
 platforms:
 - name: centos-7
@@ -354,6 +354,9 @@ platforms:
     image: centos:7
     privileged: true
     pid_one_command: /usr/lib/systemd/systemd
+    volumes:
+      - /sys/fs/cgroup:/sys/fs/cgroup:ro # required by systemd
+
 ```
 
 You can combine `intermediate_instructions` and `pid_one_command` as needed.
@@ -428,4 +431,3 @@ docker tag suite_name:latest my.computers.biz:5043/something/whatever
 docker push my.computers.biz:5043/something/whatever
 kitchen destroy
 ```
-

--- a/test/cookbooks/dokken_test/recipes/default.rb
+++ b/test/cookbooks/dokken_test/recipes/default.rb
@@ -45,7 +45,7 @@ package 'gcc' do
 end
 
 execute 'install gem bundle' do
-  command 'bundle install'
+  command '/usr/local/bin/bundle install'
   cwd '/home/notroot/kitchen-dokken'
   user 'notroot'
   live_stream false
@@ -55,7 +55,7 @@ execute 'install gem bundle' do
 end
 
 execute 'converge hello with -c' do
-  command 'bundle exec kitchen converge hello -c'
+  command '/usr/local/bin/bundle exec kitchen converge hello -c'
   cwd '/home/notroot/kitchen-dokken'
   user 'notroot'
   live_stream true
@@ -66,7 +66,7 @@ execute 'converge hello with -c' do
 end
 
 execute 'destroy hello again suite' do
-  command 'bundle exec kitchen destroy helloagain'
+  command '/usr/local/bin/bundle exec kitchen destroy helloagain'
   cwd '/home/notroot/kitchen-dokken'
   user 'notroot'
   live_stream true


### PR DESCRIPTION
fixes #96 

also: 

> Yes, it is written systemd, not system D or System D, or even SystemD. And it isn't system d either. Why? Because it's a system daemon, and under Unix/Linux those are in lower case, and get suffixed with a lower case d. And since systemd manages the system, it's called systemd. It's that simple. But then again, if all that appears too simple to you, call it (but never spell it!) System Five Hundred since D is the roman numeral for 500 (this also clarifies the relation to System V, right?). The only situation where we find it OK to use an uppercase letter in the name (but don't like it either) is if you start a sentence with systemd. On high holidays you may also spell it sÿstëmd. But then again, Système D is not an acceptable spelling and something completely different (though kinda fitting).

https://www.freedesktop.org/wiki/Software/systemd/