### PR TITLE
Use platform name for image unless specified

### DIFF
--- a/lib/kitchen/driver/dokken.rb
+++ b/lib/kitchen/driver/dokken.rb
@@ -418,7 +418,12 @@ module Kitchen
       end
 
       def platform_image
-        config[:image]
+        config[:image] || platform_image_from_name
+      end
+
+      def platform_image_from_name
+        platform, release = instance.platform.name.split('-')
+        release ? [platform, release].join(':') : platform
       end
 
       def exposed_ports(config, rules)


### PR DESCRIPTION
Currently, kitchen-dokken requires `image` to
be configured explicitly (in contrast to
kitchen-{vagrant,docker}, which derive the
image from the platform name, unless specified).

This copies the code snippet from kitchen-dokken
to use the platform name and use a `repo-tag`
name as `repo:tag` docker image.

If the platform name contains no `-`, the
`:latest` tag will be automatically applied.

Examples:

    platforms:
    - name: debian-9
        # image: debian:9
    - name: ubuntu-1604
        # image: ubuntu-1604
    - name: centos-7
        # image: centos:7
    - name: amazon
        # image name differs from platform name
        image: amazonlinux:latest

Fixes: #91