### PR TITLE
Add the retry feature

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 rvm:
-  - 2.2.5
+  - 2.3.1
 cache: bundler
 
 sudo: required

--- a/lib/kitchen/provisioner/dokken.rb
+++ b/lib/kitchen/provisioner/dokken.rb
@@ -40,8 +40,14 @@ module Kitchen
       def call(state)
         create_sandbox
         instance.transport.connection(state) do |conn|
-          conn.execute(run_command)
-        end
+          conn.execute(prepare_command)
+          conn.execute_with_retry(
+            run_command,
+            config[:retry_on_exit_code],
+            config[:max_retries],
+            config[:wait_for_retry]
+          )
+				end
       rescue Kitchen::Transport::TransportFailed => ex
         raise ActionFailed, ex.message
         # ensure

--- a/lib/kitchen/transport/dokken.rb
+++ b/lib/kitchen/transport/dokken.rb
@@ -72,7 +72,7 @@ module Kitchen
             @exit_code = o[2]
           end
 
-          raise Transport::DockerExecFailed, "Docker Exec (#{@exit_code}) for command: [#{command}]" if @exit_code != 0
+          raise Transport::DockerExecFailed.new("Docker Exec (#{@exit_code}) for command: [#{command}]", @exit_code) if @exit_code != 0
         end
 
         def upload(locals, remote)


### PR DESCRIPTION
STATE:
Cuurently, the retry kitchen-test feature is not supported

CAUSE:
The call function has been copied from an old kitchen-test version

FIX:
Copy the new from kitchen-test and pass over the right exit code

This fix https://github.com/someara/kitchen-dokken/issues/109