### PR TITLE
Fix "ports" config in ChangeLog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@
    ```
    driver:
      hostname: www.computers.biz
-     port "1234"
+     ports: "1234"
    ```
 ...or something like
 


### PR DESCRIPTION
I assume it's always `ports`.