### PR TITLE
Exclude NotFoundError from Errors that Trigger Retries

### DIFF
--- a/lib/kitchen/driver/dokken.rb
+++ b/lib/kitchen/driver/dokken.rb
@@ -520,8 +520,7 @@ module Kitchen
         rescue ::Docker::Error::ServerError, # 404
                ::Docker::Error::UnexpectedResponseError, # 400
                ::Docker::Error::TimeoutError,
-               ::Docker::Error::IOError,
-               ::Docker::Error::NotFoundError => e
+               ::Docker::Error::IOError => e
           tries -= 1
           sleep 0.1
           retry if tries > 0


### PR DESCRIPTION
This resolves https://github.com/someara/kitchen-dokken/issues/121 : Kitchen Dokken suspicious slow when destroying

Kitchen::Driver::Dokken#with_retries was catching NotFoundError.  This generally isn't something to retry on.  Caused long delays when destroying non-existant kitchens or converging when image is not available.