### PR TITLE
Only pull platform image if it is missing.

### DIFF
--- a/lib/kitchen/driver/dokken.rb
+++ b/lib/kitchen/driver/dokken.rb
@@ -386,7 +386,7 @@ module Kitchen
 
       def pull_platform_image
         debug "driver - pulling #{chef_image} #{repo(platform_image)} #{tag(platform_image)}"
-        pull_image platform_image
+        pull_if_missing platform_image
       end
 
       def pull_chef_image


### PR DESCRIPTION
Fixes #138 . Only pull platform image if it is missing. Enables users that use a private docker registry that requires authentication to pull the image before running kitchen.