### PR TITLE
Single operation for directory creation and mode

### DIFF
--- a/lib/kitchen/helpers.rb
+++ b/lib/kitchen/helpers.rb
@@ -121,12 +121,10 @@ EOF
 
     def dokken_create_sandbox
       info("Creating kitchen sandbox at #{dokken_kitchen_sandbox}")
-      FileUtils.mkdir_p(dokken_kitchen_sandbox)
-      File.chmod(0o755, dokken_kitchen_sandbox)
+      FileUtils.mkdir_p(dokken_kitchen_sandbox, :mode => 0o755)
 
       info("Creating verifier sandbox at #{dokken_verifier_sandbox}")
-      FileUtils.mkdir_p(dokken_verifier_sandbox)
-      File.chmod(0o755, dokken_verifier_sandbox)
+      FileUtils.mkdir_p(dokken_verifier_sandbox, :mode => 0o755)
     end
 
     def dokken_delete_sandbox
@@ -257,8 +255,7 @@ EOF
     def create_sandbox
       info("Creating kitchen sandbox in #{sandbox_path}")
       unless ::Dir.exist?(sandbox_path)
-        FileUtils.mkdir_p(sandbox_path)
-        File.chmod(0o755, sandbox_path)
+        FileUtils.mkdir_p(sandbox_path, :mode => 0o755)
       end
     end
   end
@@ -269,8 +266,7 @@ module Kitchen
     class Base
       def create_sandbox
         info("Creating kitchen sandbox in #{sandbox_path}")
-        FileUtils.mkdir_p(sandbox_path)
-        File.chmod(0o755, sandbox_path)
+        FileUtils.mkdir_p(sandbox_path, :mode => 0o755)
       end
 
       # this MUST be named 'sandbox_path' because ruby.
@@ -292,8 +288,7 @@ module Kitchen
       def create_sandbox
         info("Creating kitchen sandbox in #{sandbox_path}")
         unless ::Dir.exist?(sandbox_path)
-          FileUtils.mkdir_p(sandbox_path)
-          File.chmod(0o755, sandbox_path)
+          FileUtils.mkdir_p(sandbox_path, :mode => 0o755)
         end
       end
 

--- a/test/cookbooks/dokken_test/recipes/default.rb
+++ b/test/cookbooks/dokken_test/recipes/default.rb
@@ -5,6 +5,7 @@ user 'notroot' do
 end
 
 package_list = %w(
+  gcc-c++
   gcc
   git
   iputils

--- a/test/cookbooks/dokken_test/recipes/default.rb
+++ b/test/cookbooks/dokken_test/recipes/default.rb
@@ -10,6 +10,7 @@ package_list = %w(
   iputils
   libffi
   libffi-devel
+  make
   net-tools
   nmap
   procps-ng


### PR DESCRIPTION
  This attempts to address issue #105.

  There appears to be a race condition when creating a directory
  and then immediately setting its mode. This turns the two
  operations into a single one and avoids the condition.