### PR TITLE
add auth support for private registries

### DIFF
--- a/README.md
+++ b/README.md
@@ -399,6 +399,26 @@ platforms:
     intermediate_instructions:
       # prevent APT from deleting the APT folder
       - RUN rm /etc/apt/apt.conf.d/docker-clean
+
+### Docker Credentials
+
+You can set credentials for pulling images from private docker registries in a json file.
+```json
+{
+  "username": "myusername",
+  "password": "mypassword",
+  "email": "myemail@mydomain",
+  "serveraddress": "https://index.docker.io/v1/"
+}
+```
+
+Then add the `creds_file` driver configuration option.
+```yaml
+platforms:
+- name: ubuntu-16.04
+  driver:
+    image: myorg/private-ubuntu-16.04
+    creds_file: './config.json'
 ```
 
 Using dokken-images

--- a/lib/kitchen/driver/dokken.rb
+++ b/lib/kitchen/driver/dokken.rb
@@ -62,7 +62,7 @@ module Kitchen
 
       def set_creds
         if config[:creds_file]
-          @creds = JSON.parse(IO.read('config.json'))
+          @creds = JSON.parse(IO.read(config[:creds_file]))
           ::Docker.authenticate!(@creds) if @creds
         end
       end


### PR DESCRIPTION
Allows for setting creds or a json creds_file, and adjusts the docker-api calls as needed to work with the private registry.

My use case was for using private docker containers from docker in privileged mode for CI.  The changes here solved the authentication problem for my specific use case.  It looks like it should resolve #126, but would need additional verification in order to make the claim that it resolves it completely.

Specifically, it resolved the following for me:
```
ChefDK version without changes:
# kitchen create chefdk
-----> Starting Kitchen (v1.19.2)
-----> Creating <chefdk-chefdk>...
>>>>>> ------Exception-------
>>>>>> Class: Kitchen::ActionFailed
>>>>>> Message: 1 actions failed.
>>>>>>     Failed to complete #create action: [pull access denied for org/chefdk, repository does not exist or may require 'docker login'
] on chefdk-chefdk
>>>>>> ----------------------
>>>>>> Please see .kitchen/logs/kitchen.log for more details
>>>>>> Also try running `kitchen diagnose --all` for configuration

`bundle install` version with changes:
# bundle exec kitchen create chefdk
-----> Starting Kitchen (v1.20.0)
-----> Creating <chefdk-chefdk>...
       Creating kitchen sandbox at /root/.dokken/kitchen_sandbox/404b3c381a-chefdk-chefdk
       Creating verifier sandbox at /root/.dokken/verifier_sandbox/404b3c381a-chefdk-chefdk
       Building work image..
       Creating container 404b3c381a-chefdk-chefdk
       Finished creating <chefdk-chefdk> (0m4.03s).
-----> Kitchen is finished. (0m5.05s)
```