### PR TITLE
always downcase the container name

### DIFF
--- a/lib/kitchen/driver/dokken.rb
+++ b/lib/kitchen/driver/dokken.rb
@@ -214,8 +214,7 @@ module Kitchen
       end
 
       def work_image
-        return "#{image_prefix}/#{instance_name}" unless image_prefix.nil?
-        instance_name
+        [image_prefix, instance_name].compact.join('/').downcase
       end
 
       def dokken_binds

--- a/lib/kitchen/helpers.rb
+++ b/lib/kitchen/helpers.rb
@@ -163,7 +163,7 @@ EOF
 
     def instance_name
       prefix = (Digest::SHA2.hexdigest FileUtils.pwd)[0, 10]
-      "#{prefix}-#{instance.name}"
+      "#{prefix}-#{instance.name}".downcase
     end
 
     def exposed_ports
@@ -276,7 +276,7 @@ module Kitchen
 
       def instance_name
         prefix = (Digest::SHA2.hexdigest FileUtils.pwd)[0, 10]
-        "#{prefix}-#{instance.name}"
+        "#{prefix}-#{instance.name}".downcase
       end
     end
   end
@@ -298,7 +298,7 @@ module Kitchen
 
       def instance_name
         prefix = (Digest::SHA2.hexdigest FileUtils.pwd)[0, 10]
-        "#{prefix}-#{instance.name}"
+        "#{prefix}-#{instance.name}".downcase
       end
 
       def call(state)


### PR DESCRIPTION
Docker fails when it attempts to create a container with capital letters
in name. Stack trace:

```
>>>>>> ------Exception-------
>>>>>> Class: Kitchen::ActionFailed
>>>>>> Message: 1 actions failed.
>>>>>>     Failed to complete #create action: [no such image: 0d9c95481b-LP--ruby-ubuntu-1604: invalid reference format: repository name must be lowercase
] on LP--ruby-ubuntu-1604
>>>>>> ----------------------
>>>>>> Please see .kitchen/logs/kitchen.log for more details
>>>>>> Also try running `kitchen diagnose --all` for configuration

D      ------Exception-------
D      Class: Kitchen::ActionFailed
D      Message: 1 actions failed.
>>>>>>     Failed to complete #create action: [no such image: 0d9c95481b-LP--ruby-ubuntu-1604: invalid reference format: repository name must be lowercase
] on LP--ruby-ubuntu-1604
D      ----------------------
D      ------Backtrace-------
D      /home/rob/projects/chef-repo/vendor/ruby/2.4.0/gems/test-kitchen-1.20.0/lib/kitchen/command.rb:183:in `report_errors'
D      /home/rob/projects/chef-repo/vendor/ruby/2.4.0/gems/test-kitchen-1.20.0/lib/kitchen/command.rb:174:in `run_action'
D      /home/rob/projects/chef-repo/vendor/ruby/2.4.0/gems/test-kitchen-1.20.0/lib/kitchen/command/action.rb:36:in `block in call'
D      /usr/lib/ruby/2.4.0/benchmark.rb:293:in `measure'
D      /home/rob/projects/chef-repo/vendor/ruby/2.4.0/gems/test-kitchen-1.20.0/lib/kitchen/command/action.rb:34:in `call'
D      /home/rob/projects/chef-repo/vendor/ruby/2.4.0/gems/test-kitchen-1.20.0/lib/kitchen/cli.rb:52:in `perform'
D      /home/rob/projects/chef-repo/vendor/ruby/2.4.0/gems/test-kitchen-1.20.0/lib/kitchen/cli.rb:193:in `block (2 levels) in <class:CLI>'
D      /home/rob/projects/chef-repo/vendor/ruby/2.4.0/gems/thor-0.19.1/lib/thor/command.rb:27:in `run'
D      /home/rob/projects/chef-repo/vendor/ruby/2.4.0/gems/thor-0.19.1/lib/thor/invocation.rb:126:in `invoke_command'
D      /home/rob/projects/chef-repo/vendor/ruby/2.4.0/gems/thor-0.19.1/lib/thor.rb:359:in `dispatch'
D      /home/rob/projects/chef-repo/vendor/ruby/2.4.0/gems/thor-0.19.1/lib/thor/base.rb:440:in `start'
D      /home/rob/projects/chef-repo/vendor/ruby/2.4.0/gems/test-kitchen-1.20.0/bin/kitchen:13:in `block in <top (required)>'
D      /home/rob/projects/chef-repo/vendor/ruby/2.4.0/gems/test-kitchen-1.20.0/lib/kitchen/errors.rb:171:in `with_friendly_errors'
D      /home/rob/projects/chef-repo/vendor/ruby/2.4.0/gems/test-kitchen-1.20.0/bin/kitchen:13:in `<top (required)>'
D      /home/rob/projects/chef-repo/vendor/ruby/2.4.0/bin/kitchen:23:in `load'
D      /home/rob/projects/chef-repo/vendor/ruby/2.4.0/bin/kitchen:23:in `<main>'
```

The container name was infered from the suite name, it's `LP__ruby` in
my case.

Dokken supports an option to provide custom name, but it shouldn't be
necessary, I think the default name should always work.

This will downcase the container name, everything else in the output
will remain as it was (logs still output capital letters for the suite
name etc).

It fixes the problem I had, but I can't run the tests locally becuase my
docker setup has user namespaces enabled and it requires changes from
the P/R #148 to be pulled in. That said I have done the best I can to
ensure the changes added here work as expected.