### PR TITLE
Fix terminal size issue when using kitchen login

### DIFF
--- a/lib/kitchen/transport/dokken.rb
+++ b/lib/kitchen/transport/dokken.rb
@@ -167,7 +167,9 @@ module Kitchen
 
         def login_command
           @runner = options[:instance_name].to_s
-          args = ['exec', '-it', @runner, '/bin/bash', '-login', '-i']
+          cols = `tput cols`
+          lines = `tput lines`
+          args = ['exec', '-e', "COLUMNS=#{cols}", '-e', "LINES=#{lines}", '-it', @runner, '/bin/bash', '-login', '-i']
           LoginCommand.new('docker', args)
         end
 


### PR DESCRIPTION
docker exec doesn't supply terminal width and height values to containers
currently. This should really be fixed upstream but this is workaround for the
issue until then. There's a 2 year old github issue for it so I doubt it's a
priority right now.

Before:
```
sme@megatron ~ stty size
48 151

sme@megatron ~ kitchen login

root@dokken:/# stty size
0 0
```

After:
```
sme@megatron ~ stty size
48 151

sme@megatron ~ kitchen login

root@dokken:/# stty size
48 151
```

refs:
- https://github.com/moby/moby/issues/33794
- https://github.com/moby/moby/issues/10341

Signed-off-by: Sean Escriva <sean.escriva@gmail.com>