### PR TITLE
README Update: How to cache apt downloads

### DIFF
--- a/README.md
+++ b/README.md
@@ -375,6 +375,32 @@ You can combine `intermediate_instructions` and `pid_one_command` as needed.
       - RUN /usr/bin/apt-get install apt-transport-https
 ```
 
+### Caching Downloaded Files
+
+On Debian/Ubuntu systems, all files downloaded via it's package manager (`apt`) are stored at `/var/cache/apt/archives/`.
+Therefore one may save the downloads on a different volume and therefore save time. One may even use one's own apt cache folder to save even more time.
+
+On some versions of Ubuntu (16.04 at least), the container deletes all the downloads uppon every run of `apt-get update`, so that must be disabled
+
+- `apt` Caching on Ubuntu 16.04
+```yaml
+---
+driver:
+  name: dokken
+  volumes:
+  # saves the apt archieves outside of the container
+  - /var/cache/apt/archives/:/var/cache/apt/archives/
+
+platforms:
+- name: ubuntu-16.04
+  driver:
+    image: dokken/ubuntu-16.04
+    pid_one_command: /bin/systemd
+    intermediate_instructions:
+      # prevent APT from deleting the APT folder
+      - RUN rm /etc/apt/apt.conf.d/docker-clean
+```
+
 Using dokken-images
 ===================
 While the `intermediate_instructions` directive is a fine hack around the


### PR DESCRIPTION
This saved my time a lot and may save other's as well. Therefore I want to share the knowledge.
I am not sure if this should be automated, though. That's why I am just sending a `readme` change.

Changing the ubuntu image is trivial. I am unsure about always mounting the `/var/cache/apt/archives/` on a different volume. Maybe it's too much things being done behind the scenes.
