### PR TITLE
Friendly error message when docker can't be reached

### DIFF
--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -27,7 +27,7 @@ platforms:
 
   - name: fedora
     driver:
-      image: fedora:25
+      image: fedora:latest
       pid_one_command: /usr/lib/systemd/systemd
       volumes:
         - <%= ENV['PWD'] %>/.git:/opt/kitchen-dokken/.git

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,6 +11,10 @@ services: docker
 install: bundle install
 bundler_args: "--binstubs=$PWD/bin --jobs 3 --retry 3"
 
+branches:
+  only:
+  - master
+
 env:
   global:
     - KITCHEN_YAML=.kitchen.yml

--- a/Berksfile
+++ b/Berksfile
@@ -1,4 +1,3 @@
 source 'https://supermarket.chef.io'
 
 cookbook 'dokken_test', path: 'test/cookbooks/dokken_test'
-cookbook 'docker'

--- a/Gemfile
+++ b/Gemfile
@@ -4,6 +4,9 @@ gemspec
 
 gem 'berkshelf'
 gem 'kitchen-inspec'
-gem 'pry'
-gem 'pry-coolline'
 gem 'test-kitchen'
+
+group :development do
+  gem 'pry'
+  gem 'pry-coolline'
+end

--- a/Rakefile
+++ b/Rakefile
@@ -1,3 +1,2 @@
 # release tooling
 require 'bundler/gem_tasks'
-

--- a/kitchen-dokken.gemspec
+++ b/kitchen-dokken.gemspec
@@ -1,5 +1,4 @@
-# coding: utf-8
-lib = File.expand_path('../lib', __FILE__)
+lib = File.expand_path('lib', __dir__)
 $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 require 'kitchen/driver/dokken_version'
 
@@ -18,7 +17,7 @@ Gem::Specification.new do |spec|
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ['lib']
 
-  spec.add_dependency 'test-kitchen', '~> 1.15'
   spec.add_dependency 'docker-api', '~> 1.33'
   spec.add_dependency 'lockfile', '~> 2.1'
+  spec.add_dependency 'test-kitchen', '~> 1.15'
 end

--- a/lib/kitchen/driver/dokken.rb
+++ b/lib/kitchen/driver/dokken.rb
@@ -438,7 +438,6 @@ module Kitchen
               rescue ::Docker::Error::ConflictError
                 debug "driver - rescue ConflictError: #{args['name']}"
                 with_retries { @container = ::Docker::Container.get(args['name'], {}, docker_connection) }
-
               end
             end
           rescue ::Docker::Error => e

--- a/lib/kitchen/driver/dokken_version.rb
+++ b/lib/kitchen/driver/dokken_version.rb
@@ -1,4 +1,3 @@
-# -*- encoding: utf-8 -*-
 #
 # Author:: Sean OMeara (<sean@sean.io>)
 #

--- a/lib/kitchen/helpers.rb
+++ b/lib/kitchen/helpers.rb
@@ -117,6 +117,9 @@ VOLUME /opt/verifier
 
     def docker_info
       @docker_info ||= ::Docker.info
+    rescue Excon::Error::Socket
+      puts "kitchen-dokken could not connect to the docker host at #{default_docker_host}. Is docker running?"
+      exit!
     end
 
     def dokken_create_sandbox

--- a/lib/kitchen/helpers.rb
+++ b/lib/kitchen/helpers.rb
@@ -24,7 +24,7 @@ module Dokken
     def insecure_ssh_public_key
       <<-EOF
 ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCoJwyW7qNhw+NTuOjC4+RVpESl+JBXebXzB7JqxRgKAbymq6B39azEAiNx5NzHkWcQmOyQNhFpKFSAufegcXRS4ctS1LcElEoXe9brDAqKEBSkmnXYfZXMNIG0Enw4+5W/rZxHFCAlsUSAHYtYZEs+3CgbIWuHhZ95C8UC6nGLWHNZOjcbsYZFrnFfO0qg0ene2w8LKhxqj5X0MRSdCIn1IwyxIbl5NND5Yk1Hx8JKsJtTiNTdxssiMgmM5bvTbYQUSf8pbGrRI30VQKBgQ8/UkidZbaTfvzWXYpwcDUERSbzEYCvkUytTemZIv6uhpPxqkfjl6KEOOml/iGqquPEr test-kitchen-rsa
-EOF
+      EOF
     end
 
     def insecure_ssh_private_key
@@ -56,7 +56,7 @@ D58kDk7684mKwKotr34NfqkFl2ZJ8T+f8pVwmUNvtPtX0j8IO7/6bfIjPTFyNeFJ
 XuIb2Qt4MLHABySsk653LDw/jTIGV26c068nZryq5OUPxk67Xgod54jKgOwjgjZS
 X8N2N9ZNnORJqK374yGj1jWUU66mQhPvn49QpG8P2HEoh2RQjNvyHA==
 -----END RSA PRIVATE KEY-----
-EOF
+      EOF
     end
 
     def data_dockerfile
@@ -83,7 +83,7 @@ CMD [ "/usr/sbin/sshd", "-D", "-p", "22", "-o", "UseDNS=no", "-o", "UsePrivilege
 
 VOLUME /opt/kitchen
 VOLUME /opt/verifier
-EOF
+      EOF
     end
 
     def create_data_image
@@ -121,10 +121,10 @@ EOF
 
     def dokken_create_sandbox
       info("Creating kitchen sandbox at #{dokken_kitchen_sandbox}")
-      FileUtils.mkdir_p(dokken_kitchen_sandbox, :mode => 0o755)
+      FileUtils.mkdir_p(dokken_kitchen_sandbox, mode: 0o755)
 
       info("Creating verifier sandbox at #{dokken_verifier_sandbox}")
-      FileUtils.mkdir_p(dokken_verifier_sandbox, :mode => 0o755)
+      FileUtils.mkdir_p(dokken_verifier_sandbox, mode: 0o755)
     end
 
     def dokken_delete_sandbox

--- a/lib/kitchen/provisioner/dokken.rb
+++ b/lib/kitchen/provisioner/dokken.rb
@@ -1,4 +1,3 @@
-# -*- encoding: utf-8 -*-
 #
 # Author:: Sean OMeara (<sean@sean.io>)
 #

--- a/test/cookbooks/dokken_test/README.md
+++ b/test/cookbooks/dokken_test/README.md
@@ -1,1 +1,0 @@
-this is a test cookbook

--- a/test/cookbooks/dokken_test/metadata.rb
+++ b/test/cookbooks/dokken_test/metadata.rb
@@ -1,4 +1,3 @@
 name 'dokken_test'
 version '0.0.1'
-
-depends 'docker', '<= 2.15.14'
+depends 'docker'

--- a/test/cookbooks/dokken_test/recipes/default.rb
+++ b/test/cookbooks/dokken_test/recipes/default.rb
@@ -38,7 +38,7 @@ git '/home/notroot/kitchen-dokken' do
 end
 
 execute 'install gem bundle' do
-  command '/usr/bin/bundle install'
+  command '/usr/bin/bundle install --without development'
   cwd '/home/notroot/kitchen-dokken'
   user 'notroot'
   live_stream false

--- a/test/cookbooks/dokken_test/recipes/default.rb
+++ b/test/cookbooks/dokken_test/recipes/default.rb
@@ -4,7 +4,7 @@ user 'notroot' do
   action :create
 end
 
-package_list = %w(
+package %w(
   gcc-c++
   gcc
   git
@@ -24,8 +24,6 @@ package_list = %w(
   telnet
   which
 )
-
-package package_list
 
 docker_service 'default' do
   host ['tcp://127.0.0.1']


### PR DESCRIPTION
This is the #1 error you run into with kitchen-dokken and the error is useless. Avoid the stacktrace and just toss a friendly error.

```
kitchen-dokken could not connect to the docker host at unix:///var/run/docker.sock. Is docker running?
```