### PR TITLE
Allow building data_image from alternate registry

### DIFF
--- a/lib/kitchen/driver/dokken.rb
+++ b/lib/kitchen/driver/dokken.rb
@@ -40,6 +40,7 @@ module Kitchen
       default_config :chef_image, 'chef/chef'
       default_config :chef_version, 'latest'
       default_config :data_image, 'dokken/kitchen-cache:latest'
+      default_config :data_image_registry, 'docker.io'
       default_config :dns, nil
       default_config :dns_search, nil
       default_config :docker_info, docker_info

--- a/lib/kitchen/helpers.rb
+++ b/lib/kitchen/helpers.rb
@@ -61,7 +61,7 @@ X8N2N9ZNnORJqK374yGj1jWUU66mQhPvn49QpG8P2HEoh2RQjNvyHA==
 
     def data_dockerfile
       <<-EOF
-FROM centos:7
+FROM #{data_image_registry}/centos:7
 MAINTAINER Sean OMeara \"sean@sean.io\"
 ENV LANG en_US.UTF-8
 


### PR DESCRIPTION
I believe this addresses #147. Allows for fetching the centos:7 image through a corporate proxy.