### PR TITLE
Add ability to disable user namespace mode when running privileged containers

### DIFF
--- a/README.md
+++ b/README.md
@@ -374,6 +374,22 @@ You can combine `intermediate_instructions` and `pid_one_command` as needed.
       - RUN /usr/bin/apt-get install apt-transport-https
 ```
 
+### Running with User Namespaces enabled
+
+IF you are running a Docker daemon with user namespace remapping enabled you'll get errors running dokken with priveleged containers.
+
+To mitigate this, add the following to your driver definition:
+```yaml
+platforms:
+- name: centos-7
+  driver:
+    image: centos:7
+    privileged: true
+    userns_host: true
+```
+
+This will disable user namespaces for the running container.
+
 ### Caching Downloaded Files
 
 On Debian/Ubuntu systems, all files downloaded via it's package manager (`apt`) are stored at `/var/cache/apt/archives/`.

--- a/lib/kitchen/driver/dokken.rb
+++ b/lib/kitchen/driver/dokken.rb
@@ -58,6 +58,7 @@ module Kitchen
       default_config :tmpfs, {}
       default_config :volumes, nil
       default_config :write_timeout, 3600
+      default_config :userns_host, false
 
       # (see Base#create)
       def create(state)
@@ -308,6 +309,9 @@ module Kitchen
         }
         unless self[:entrypoint].to_s.empty?
           config['Entrypoint'] = self[:entrypoint]
+        end
+        if self[:userns_host]
+          config['HostConfig']['UsernsMode'] = 'host'
         end
         runner_container = run_container(config)
         state[:runner_container] = runner_container.json

--- a/lib/kitchen/driver/dokken_version.rb
+++ b/lib/kitchen/driver/dokken_version.rb
@@ -18,6 +18,6 @@
 module Kitchen
   module Driver
     # Version string for Dokken Kitchen driver
-    DOKKEN_VERSION = '2.6.7'.freeze
+    DOKKEN_VERSION = '2.6.8'.freeze
   end
 end


### PR DESCRIPTION
When your Docker daemon is running with user namespace remapping it is
not possible to run a privileged container unless you pass the
`--user-ns 'host'` flag. This PR add's the ability to pass that config
option to the container create call.

![](https://media0.giphy.com/media/8QmBtM43eMPKg/200w.gif)

Signed-off-by: Elliott Davis <elliott@excellent.io>