### PR TITLE
Enable local image testing with a new pull_platform_image config

### DIFF
--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -32,10 +32,15 @@ platforms:
       volumes:
         - <%= ENV['PWD'] %>/.git:/opt/kitchen-dokken/.git
 
+  - name: local_image
+    driver:
+      image: local-example:latest
+      pull_platform_image: false
+
 suites:
   - name: default
-    excludes:
-      - hello
+    includes:
+      - fedora
     run_list:
       - recipe[dokken_test::default]
     attributes:
@@ -51,8 +56,8 @@ suites:
       hostname: hello.computers.biz
       ports: '1234'
       pid_one_command: ''
-    excludes:
-      - fedora
+    includes:
+      - hello
 
   - name: helloagain
     driver:
@@ -63,5 +68,9 @@ suites:
         - '8301'
         - '8301:8301/udp'
         - '127.0.0.1:8500:8500'
-    excludes:
-      - fedora
+    includes:
+      - hello
+
+  - name: local_image
+    includes:
+      - local_image

--- a/README.md
+++ b/README.md
@@ -464,6 +464,19 @@ provisioner:
   chef_output_format: minimal
 ```
 
+Disable pulling platform images
+===============================
+
+To test a locally built image without pulling it first, one can disable
+pulling of platform images, which will avoid pulling images that already
+exist locally.
+
+```yaml
+driver:
+  name: dokken
+  pull_platform_image: false
+```
+
 Testing without Chef
 ====================
 

--- a/lib/kitchen/driver/dokken.rb
+++ b/lib/kitchen/driver/dokken.rb
@@ -58,6 +58,7 @@ module Kitchen
       default_config :tmpfs, {}
       default_config :volumes, nil
       default_config :write_timeout, 3600
+      default_config :pull_platform_image, true
 
       # (see Base#create)
       def create(state)
@@ -386,7 +387,7 @@ module Kitchen
 
       def pull_platform_image
         debug "driver - pulling #{chef_image} #{repo(platform_image)} #{tag(platform_image)}"
-        pull_image platform_image
+        config[:pull_platform_image] ? pull_image(platform_image) : pull_if_missing(platform_image)
       end
 
       def pull_chef_image

--- a/test/cookbooks/dokken_test/recipes/default.rb
+++ b/test/cookbooks/dokken_test/recipes/default.rb
@@ -72,3 +72,21 @@ execute 'destroy hello again suite' do
               'DOCKER_HOST' => 'tcp://127.0.0.1:2375'
   action :run
 end
+
+docker_tag 'local-example' do
+  target_repo 'fedora'
+  target_tag 'latest'
+  to_repo 'local-example'
+  to_tag 'latest'
+end
+
+execute 'Test Kitchen verify without image pull' do
+  command '/usr/bin/bundle exec kitchen test local_image -l debug'
+  cwd '/home/notroot/kitchen-dokken'
+  user 'notroot'
+  live_stream true
+  environment 'PATH' => '/usr/bin:/usr/local/bin:/home/notroot/bin',
+              'HOME' => '/home/notroot',
+              'DOCKER_HOST' => 'tcp://127.0.0.1:2375'
+  action :run
+end


### PR DESCRIPTION
enables testing of platforms with images that only/already exist locally (desirable for pre-push testing in CI or bandwidth preservation) by adding a config option to disable kitchen-dokken's currently required pre-test pull of the platform image.

obviates #139, fixes #138 