### PR TITLE
Update to handle Chef 15 EULA acceptance

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,13 +28,15 @@ export KITCHEN_LOCAL_YAML=.kitchen.dokken.yml
 ---
 driver:
   name: dokken
-  chef_version: latest
 
 transport:
   name: dokken
 
 provisioner:
   name: dokken
+  product_name: chef
+  product_version: latest
+  channel: stable
 
 verifier:
   name: inspec


### PR DESCRIPTION
The goal of this PR is to allow license passthrough and acceptance as implemented in the [base driver](https://github.com/test-kitchen/test-kitchen/pull/1544). Users can accept the license by adding `chef_license` under the provisioner config, or through the interactive prompt. 

The issue users ran into recently is that the license-acceptance library attempts to check the product version and only apply the license acceptance flow if the chef version is >= 15. But this library sets the chef version in the _driver_ config instead of the provisioner config.

This PR updates the driver config to inherit the version from the provisioner config. Users who specify their own driver config like:
```
driver:
  chef_image: "chef/chef"
  chef_version: "14"
```
will now correctly not prompt for the license. However, they will get a deprecation warning about `chef_version` and prompting them to use the `provisioner` settings to specify the chef version. They should update their config to look like:
```
provisioner:
  product_name: "chef"
  product_version: "14"
```