### PR TITLE
Copy chef_version into provisioner so license acceptance works correctly

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,6 +17,7 @@ env:
   global:
     - KITCHEN_YAML=.kitchen.yml
     - INSTANCE=default-fedora
+    - CHEF_LICENSE="accept-no-persist"
 
 before_install:
   - sudo apt-get -qq update

--- a/lib/kitchen/provisioner/dokken.rb
+++ b/lib/kitchen/provisioner/dokken.rb
@@ -37,6 +37,20 @@ module Kitchen
       default_config :docker_info, docker_info
       default_config :docker_host_url, default_docker_host
 
+      # Dokken is weird - the provisioner inherits from ChefZero but does not install
+      # chef-client. The version of chef used is customized by users in the driver
+      # section since it is just downloading a specific Docker image of Chef Client.
+      # In order to get the license-acceptance code working though (which depends on
+      # the product_version from the provisioner) we need to copy the value from the
+      # driver and set it here. If we remove this, users will set their chef_version
+      # to 14 in the driver and still get prompted for license acceptance because
+      # the ChefZero provisioner defaults product_version to 'latest'.
+      default_config :product_name, 'chef'
+      default_config :product_version do |provisioner|
+        driver = provisioner.instance.driver
+        driver[:chef_version]
+      end
+
       # (see Base#call)
       def call(state)
         create_sandbox


### PR DESCRIPTION
I originally thought about deprecating the `chef_version` attribute in
the driver but instead opted to have this driver continue working like
customers expect. It is a weird case because it extends the ChefZero
provisioner but does not ever install chef - the driver selects a docker
image of chef to run. The license acceptance logic depends on
`product_version` being set to the correct version so we need to copy it
from the driver into the provisioner.

Replaces https://github.com/someara/kitchen-dokken/pull/177