### PR TITLE
By default pull the chef docker image on every run

### DIFF
--- a/README.md
+++ b/README.md
@@ -457,7 +457,7 @@ provisioner:
   chef_output_format: minimal
 ```
 
-### Disable pulling platform images
+### Disable pulling platform Docker images
 
 To test a locally built image without pulling it first, one can disable
 pulling of platform images, which will avoid pulling images that already
@@ -467,6 +467,16 @@ exist locally.
 driver:
   name: dokken
   pull_platform_image: false
+```
+
+### Disable pulling chef Docker images
+
+To skip the pulling of the Chef Docker image unless it doesn't exist locally:
+
+```yaml
+driver:
+  name: dokken
+  pull_chef_image: false
 ```
 
 ### Testing without Chef

--- a/lib/kitchen/driver/dokken.rb
+++ b/lib/kitchen/driver/dokken.rb
@@ -59,6 +59,7 @@ module Kitchen
       default_config :volumes, nil
       default_config :write_timeout, 3600
       default_config :pull_platform_image, true
+      default_config :pull_chef_image, true
 
       # (see Base#create)
       def create(state)
@@ -392,7 +393,7 @@ module Kitchen
 
       def pull_chef_image
         debug "driver - pulling #{chef_image} #{repo(chef_image)} #{tag(chef_image)}"
-        pull_if_missing chef_image
+        config[:pull_chef_image] ? pull_image(chef_image) : pull_if_missing(chef_image)
       end
 
       def delete_image(name)


### PR DESCRIPTION
Right now if you specify latest or current chef images you won't ever get that image updated, which makes dokken not do what you'd expect. Now we pull on every run so you actually test on new versions. This does what you'd expect. If you want to turn it off there's a new config option: pull_chef_image

Signed-off-by: Tim Smith <tsmith@chef.io>