### PR TITLE
correct container env arg (env -> Env) to match driver config

### DIFF
--- a/lib/kitchen/driver/dokken.rb
+++ b/lib/kitchen/driver/dokken.rb
@@ -436,9 +436,9 @@ module Kitchen
       rescue
         with_retries do
           begin
-            args['env'] = [] if args['env'].nil?
-            args['env'] << 'TEST_KITCHEN=1'
-            args['env'] << "CI=#{ENV['CI']}" if ENV.include? 'CI'
+            args['Env'] = [] if args['Env'].nil?
+            args['Env'] << 'TEST_KITCHEN=1'
+            args['Env'] << "CI=#{ENV['CI']}" if ENV.include? 'CI'
             info "Creating container #{args['name']}"
             debug "driver - create_container args #{args}"
             with_retries do


### PR DESCRIPTION
Previously, if you added an `env:` section to your driver config in `.kitchen.yml`, those variables we'ren't getting propagated to the eventual container. 

Signed-off-by: Josh Brand <jbrand@chef.io>