### PR TITLE
Adds detection of Docker Desktop for Dokken on Windows

### DIFF
--- a/lib/kitchen/helpers.rb
+++ b/lib/kitchen/helpers.rb
@@ -261,6 +261,7 @@ VOLUME /opt/verifier
     end
 
     def remote_docker_host?
+      return false if config[:docker_info]["OperatingSystem"].include?("Docker Desktop")
       return false if config[:docker_info]["OperatingSystem"].include?("Boot2Docker")
       return true if /^tcp:/.match?(config[:docker_host_url])
 


### PR DESCRIPTION
# Description

Taking another shot at Dokken on Windows with Docker Desktop with WSL2 integration, I was running into #137 when attempting to run Kitchen from Windows.

By adding detection of Docker Desktop (vs Boot2Docker which I believe was Docker Toolbox?) it allowed execution to be successful.

## Issues Resolved

#137

## Test Execution

```
PS C:\git_workspace\sous-chefs\java> kitchen converge corretto-16-centos-7
-----> Starting Test Kitchen (v3.1.0)
-----> Converging <corretto-16-centos-7>...
       Creating kitchen sandbox in C:/Users/Jared/.dokken/kitchen_sandbox/d5f42dc2a9-corretto-16-centos-7
       Preparing dna.json
       Resolving cookbook dependencies with Berkshelf 7.2.2...
       Removing non-cookbook files before transfer
       Preparing validation.pem
       Preparing client.rb
Starting Chef Infra Client, version 17.3.44
Patents: https://www.chef.io/patents
[2021-10-22T04:27:30+00:00] ERROR: shard_seed: Failed to get dmi property serial_number: is dmidecode installed?
Creating a new client identity for corretto-16-centos-7 using the validator key.
resolving cookbooks for run list: ["test::corretto"]
Synchronizing Cookbooks:
  - test (0.1.0)
  - java (10.1.1)
  - line (4.4.2)
Installing Cookbook Gems:
Compiling Cookbooks...
Converging 7 resources
Recipe: test::corretto
  * corretto_install[16] action install
    * directory[/usr/lib/jvm] action create (up to date)
    * remote_file[/opt/kitchen/cache/amazon-corretto-16-x64-linux-jdk.tar.gz] action create
      - create new file /opt/kitchen/cache/amazon-corretto-16-x64-linux-jdk.tar.gz
      - update content in file /opt/kitchen/cache/amazon-corretto-16-x64-linux-jdk.tar.gz from none to dd2ef2
      (file sizes exceed 10000000 bytes, diff output suppressed)
      - change mode from '' to '0644'
    * archive_file[/opt/kitchen/cache/amazon-corretto-16-x64-linux-jdk.tar.gz] action extract (up to date)
    * template[/usr/lib/jvm/.java-16-corretto.jinfo] action create (skipped due to only_if)
    * java_alternatives[set-java-alternatives] action set (up to date)

Recipe: test::java_cert
  * cookbook_file[/tmp/java_certificate_test.pem] action create (up to date)
  * java_certificate[java_certificate_test] action install (up to date)
  * java_certificate[java_certificate_ssl_endpoint] action install
    - add certificate java_certificate_ssl_endpoint to keystore /usr/lib/jvm/java-16-corretto/amazon-corretto-16.0.2.7.1-linux-x64/lib/security/cacerts
  * java_certificate[java_certificate_ssl_endpoint] action remove
    - remove certificate java_certificate_ssl_endpoint from /usr/lib/jvm/java-16-corretto/amazon-corretto-16.0.2.7.1-linux-x64/lib/security/cacerts
  * java_certificate[java_certificate_ssl_endpoint_starttls_smtp] action install
    - add certificate java_certificate_ssl_endpoint_starttls_smtp to keystore /usr/lib/jvm/java-16-corretto/amazon-corretto-16.0.2.7.1-linux-x64/lib/security/cacerts
  * java_certificate[java_certificate_ssl_endpoint_starttls_smtp] action remove
    - remove certificate java_certificate_ssl_endpoint_starttls_smtp from /usr/lib/jvm/java-16-corretto/amazon-corretto-16.0.2.7.1-linux-x64/lib/security/cacerts

Running handlers:
Running handlers complete
Chef Infra Client finished, 6/12 resources updated in 26 seconds
       Finished converging <corretto-16-centos-7> (0m31.26s).
-----> Test Kitchen is finished. (0m35.15s)
```

## Check List

- [ ] All tests pass. See TESTING.md for details.
- [ ] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable.
