### PR TITLE
Updates transport for color output with Kitchen::Logger

### DIFF
--- a/lib/kitchen/transport/dokken.rb
+++ b/lib/kitchen/transport/dokken.rb
@@ -69,7 +69,9 @@ module Kitchen
 
           with_retries { @runner = ::Docker::Container.get(instance_name, {}, docker_connection) }
           with_retries do
-            o = @runner.exec(Shellwords.shellwords(command), wait: options[:timeout], "e" => { "TERM" => "xterm" }) { |_stream, chunk| print chunk.to_s }
+            o = @runner.exec(Shellwords.shellwords(command), wait: options[:timeout], "e" => { "TERM" => "xterm" }) do |_stream, chunk|
+              logger << chunk
+            end
             @exit_code = o[2]
           end
 
@@ -224,6 +226,7 @@ module Kitchen
       # @api private
       def connection_options(data)
         opts = {}
+        opts[:logger] = logger
         opts[:host_ip_override] = config[:host_ip_override]
         opts[:docker_host_url] = config[:docker_host_url]
         opts[:docker_host_options] = ::Docker.options


### PR DESCRIPTION
Signed-off-by: Collin McNeese <cmcneese@chef.io>

# Description

Updates transport configuration to use `Kitchen::Logger` which adds color output for suites (also respects the `--no-color` flag available)

Inspired by #5 but minimized configuration changes and does not add an extra new-line character after lines.

Existing output:
![image](https://user-images.githubusercontent.com/8185808/138562159-1370151c-538e-4ac2-8af2-addb782e6da6.png)

Updated output:
![image](https://user-images.githubusercontent.com/8185808/138562165-dee56594-3114-4447-b025-15597ec6aa85.png)

Running with multiple suites:
![image](https://user-images.githubusercontent.com/8185808/138562172-432cd9b3-fca0-49fb-86f2-82626d5dfb3e.png)


## Issues Resolved

#236 

## Check List

- [X] All tests pass. See TESTING.md for details.
- [ ] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable.
