### PR TITLE
fix(provisioner): guard check_license against non-omnibus parents

### DIFF
--- a/lib/kitchen/provisioner/dokken.rb
+++ b/lib/kitchen/provisioner/dokken.rb
@@ -90,7 +90,17 @@ module Kitchen
       # deprecation warning. That warning concerns the omnibus *download*
       # mechanism, which dokken does not use — the chef/cinc binary is
       # mounted from a volume container, not downloaded via omnitruck.
+      #
+      # When the resolved parent is kitchen-cinc's CincInfra (which rebinds
+      # Kitchen::Provisioner::ChefInfra in Cinc Workstation 26+), there is no
+      # omnibus warning to suppress, license_acceptance_id is not defined,
+      # and the LicenseAcceptance constant is not autoloaded — delegate to
+      # super in that case so the parent's own check_license runs. We test
+      # for both because a partial drop-in shim may define
+      # license_acceptance_id without pulling in license-acceptance.
       def check_license
+        return super unless respond_to?(:license_acceptance_id, true) && defined?(LicenseAcceptance)
+
         name = license_acceptance_id
         version = product_version
         debug("Checking if we need to prompt for license acceptance on product: #{name} version: #{version}.")

--- a/spec/kitchen/provisioner/dokken_spec.rb
+++ b/spec/kitchen/provisioner/dokken_spec.rb
@@ -85,5 +85,44 @@ describe Kitchen::Provisioner::Dokken do
 
       provisioner.check_license
     end
+
+    # Helper: patch the parent's check_license to a sentinel so we can
+    # verify our override delegated via super, then restore it.
+    def with_stubbed_super
+      parent = Kitchen::Provisioner::ChefInfra
+      original = parent.instance_method(:check_license)
+      parent.define_method(:check_license) { :super_called }
+      begin
+        yield
+      ensure
+        parent.define_method(:check_license, original)
+      end
+    end
+
+    it "delegates to super when the parent doesn't define license_acceptance_id (kitchen-cinc parent)" do
+      # Simulate the kitchen-cinc rebinding where ChefInfra is an alias for
+      # CincInfra and license_acceptance_id is not defined.
+      provisioner.stubs(:respond_to?).with(any_parameters).returns(true)
+      provisioner.stubs(:respond_to?).with(:license_acceptance_id, true).returns(false)
+
+      with_stubbed_super do
+        _(provisioner.check_license).must_equal :super_called
+      end
+    end
+
+    it "delegates to super when LicenseAcceptance is not loaded (partial cinc shim)" do
+      # Simulate a partial kitchen-cinc drop-in shim: license_acceptance_id
+      # exists but the LicenseAcceptance constant isn't autoloaded — our body
+      # would crash on Acceptor.new, so the guard must delegate instead.
+      stash = LicenseAcceptance
+      Object.send(:remove_const, :LicenseAcceptance)
+      begin
+        with_stubbed_super do
+          _(provisioner.check_license).must_equal :super_called
+        end
+      ensure
+        Object.const_set(:LicenseAcceptance, stash)
+      end
+    end
   end
 end


### PR DESCRIPTION
PR #381 added a check_license override that calls license_acceptance_id and
LicenseAcceptance::Acceptor, both of which are kitchen-omnibus-chef ChefBase
internals. In Cinc Workstation 26+ the kitchen-cinc gem rebinds
Kitchen::Provisioner::ChefInfra to inherit from CincInfra/CincBase, which
doesn't expose either — so converge fails with "undefined local variable or
method 'license_acceptance_id'" (#383).

Guard the override on both `respond_to?(:license_acceptance_id, true)` and
`defined?(LicenseAcceptance)`; delegate to super otherwise so the parent's own
check_license runs. The omnibus path is unchanged.

Verified against Cinc Workstation 26.0.2: kitchen converge reproduces the
failure with stock kitchen-dokken 2.23.0 and succeeds with the patched
provisioner.

Fixes #383

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>
Signed-off-by: Lance Albertson <lance@osuosl.org>

# Description

Please describe what this change achieves

## Issues Resolved

List any existing issues this PR resolves, or any Discourse or
StackOverflow discussions that are relevant

## Type of Change

Our release process assumes you are using [Conventional Commit messages](https://www.conventionalcommits.org/en/v1.0.0/).

The most important prefixes you should have in mind are:

- `_fix_`: which represents bug fixes, and correlates to a SemVer patch.
- `_feat_`: which represents a new feature, and correlates to a SemVer minor.
- `_feat!_`:, or `fix!:`, `refactor!:`, etc., which represent a breaking change (indicated by the !) and will result in a major version change.

If you have not included a conventional commit message this can be fixed on merge.

## Check List

- [ ] New functionality includes tests
- [ ] All tests pass
- [ ] Commit message includes a [Conventional Commit Message](https://www.conventionalcommits.org/en/v1.0.0)
