### PR TITLE
fix: scope registry credentials per registry and honor docker_config_creds

### DIFF
--- a/README.md
+++ b/README.md
@@ -697,7 +697,11 @@ And the `creds.json` file may look like this:
 
 ### Docker config file auth
 
-Instead of using a `creds_file`, you can read authentication information from your docker config at `~/.docker/config.json`
+Instead of using a `creds_file`, authentication information is read from your
+docker config at `~/.docker/config.json`. This is enabled by default; set
+`docker_config_creds: false` to ignore that file and pull anonymously. The
+examples below set `docker_config_creds: true` explicitly, which is redundant
+but harmless.
 
 ```yaml
 platforms:
@@ -740,6 +744,15 @@ and your docker config has
 ```
 
 Then `kitchen-dokken` will run the `docker-credential-example-cloud` command to get the credentials.
+
+Credentials are scoped to the registry an image is pulled from, similarly to
+the way the `docker` CLI scopes them. An image whose registry has no entry in
+`~/.docker/config.json` is pulled anonymously rather than with some other
+registry's credentials. Images without a registry prefix (`almalinux:9`,
+`dokken/almalinux-8`) resolve to Docker Hub, so they use the
+`https://index.docker.io/v1/` entry; `docker.io` and `registry-1.docker.io`
+are also accepted as Hub aliases, which is slightly more permissive than the
+CLI.
 
 ## FAQ
 

--- a/lib/kitchen/driver/dokken.rb
+++ b/lib/kitchen/driver/dokken.rb
@@ -81,7 +81,7 @@ module Kitchen
       default_config :write_timeout, 3600
       default_config :user_ns_mode, nil
       default_config :creds_file, nil
-      default_config :docker_config_creds, false
+      default_config :docker_config_creds, true
 
       # (see Base#create)
       def create(state)
@@ -513,20 +513,68 @@ module Kitchen
         @docker_config_creds
       end
 
+      # The `auths` key `docker login` itself writes for Docker Hub.
+      DOCKER_HUB_REGISTRY_KEY = "https://index.docker.io/v1/".freeze
+
+      # Registry hosts that all refer to Docker Hub. Docker writes the legacy
+      # v1 URL above, but hand-written and tool-generated configs use any of
+      # these. Listed in preference order.
+      DOCKER_HUB_HOSTS = %w{index.docker.io docker.io registry-1.docker.io}.freeze
+
+      # An explicit "no credentials" value. Returning nil here instead would let
+      # docker-api fall back to the process-global ::Docker.creds, which
+      # authenticate! populates from creds_file and never clears -- so another
+      # instance's private registry password would be sent to this registry,
+      # which is the very leak this scoping exists to prevent.
+      NO_DOCKER_CREDS = {}.freeze
+
+      # Return the registry host an image reference points at, or nil when the
+      # reference resolves to Docker Hub. The leading path component only names
+      # a registry when it contains a "." or a ":", or is exactly "localhost" --
+      # the same heuristic Docker uses to tell "quay.io/org/image" apart from
+      # the Hub shorthand "dokken/almalinux-8".
+      def image_registry_host(image)
+        first, remainder = image.split("/", 2)
+        return nil if remainder.nil?
+        return nil unless first.include?(".") || first.include?(":") || first == "localhost"
+
+        first
+      end
+
+      # Look up the ~/.docker/config.json entry that applies to an image's
+      # registry. Returns nil when that registry has no entry so the pull is
+      # attempted anonymously, rather than offering it another registry's
+      # credentials.
+      # Pick the config.json key that holds the Docker Hub credentials. A
+      # config may spell Hub several ways, so prefer the canonical key and then
+      # a fixed alias order rather than whichever happens to be listed first.
+      def docker_hub_creds_key
+        keys = docker_config_creds.keys.select { |k| DOCKER_HUB_HOSTS.include?(parse_registry_host(k)) }
+        return if keys.empty?
+
+        keys.find { |k| k == DOCKER_HUB_REGISTRY_KEY } ||
+          keys.min_by { |k| DOCKER_HUB_HOSTS.index(parse_registry_host(k)) }
+      end
+
+      def docker_config_creds_for_image(image)
+        host = image_registry_host(image)
+
+        key = if host.nil? || DOCKER_HUB_HOSTS.include?(host)
+                docker_hub_creds_key
+              else
+                docker_config_creds.keys.find { |k| parse_registry_host(k) == host }
+              end
+        return if key.nil?
+
+        c = docker_config_creds[key]
+        c.respond_to?(:call) ? c.call : c
+      end
+
       def docker_creds_for_image(image)
         return docker_creds if config[:creds_file]
+        return NO_DOCKER_CREDS unless config[:docker_config_creds]
 
-        image_registry = image.split("/").first
-
-        # NOTE: Try to use DockerHub auth if exact registry match isn't found
-        default_registry = "https://index.docker.io/v1/"
-        if docker_config_creds.key?(image_registry)
-          c = docker_config_creds[image_registry]
-          c.respond_to?(:call) ? c.call : c
-        elsif docker_config_creds.key?(default_registry)
-          c = docker_config_creds[default_registry]
-          c.respond_to?(:call) ? c.call : c
-        end
+        docker_config_creds_for_image(image) || NO_DOCKER_CREDS
       end
 
       def pull_platform_image
@@ -758,7 +806,7 @@ module Kitchen
             original_image = Docker::Image.get(path, { "platform" => oci_platform(config[:platform]) }, docker_connection)
           end
 
-          new_image = Docker::Image.create({ "fromImage" => path, "platform" => config[:platform] }, docker_creds_for_image(image), docker_connection)
+          new_image = Docker::Image.create({ "fromImage" => path, "platform" => config[:platform] }, docker_creds_for_image(path), docker_connection)
 
           !(original_image&.id&.start_with?(new_image.id))
         end

--- a/spec/kitchen/driver/dokken_spec.rb
+++ b/spec/kitchen/driver/dokken_spec.rb
@@ -188,4 +188,103 @@ describe Kitchen::Driver::Dokken do
       driver.send(:run_container, { "name" => "runner", "Image" => "img" }, platform: "linux/arm64/v8")
     end
   end
+
+  describe "#image_registry_host" do
+    it "is nil for a bare Docker Hub official image" do
+      _(driver.send(:image_registry_host, "almalinux:9")).must_be_nil
+    end
+
+    it "is nil for a Docker Hub user image, which is not a registry" do
+      _(driver.send(:image_registry_host, "dokken/almalinux-8:latest")).must_be_nil
+    end
+
+    it "is the host when the first component contains a dot" do
+      _(driver.send(:image_registry_host, "quay.io/almalinuxorg/almalinux:10")).must_equal "quay.io"
+    end
+
+    it "is the host when the first component contains a port" do
+      _(driver.send(:image_registry_host, "localhost:5000/almalinux:9")).must_equal "localhost:5000"
+    end
+
+    it "is the host for a bare localhost registry" do
+      _(driver.send(:image_registry_host, "localhost/almalinux:9")).must_equal "localhost"
+    end
+  end
+
+  describe "#docker_creds_for_image" do
+    let(:hub_creds)  { { serveraddress: "https://index.docker.io/v1/", username: "hub", password: "hub-secret" } }
+    let(:quay_creds) { { serveraddress: "quay.io", username: "quay", password: "quay-secret" } }
+    let(:hub_only)   { { "https://index.docker.io/v1/" => hub_creds } }
+
+    def creds_for(image, config_creds)
+      driver.stubs(:docker_config_creds).returns(config_creds)
+      driver.send(:docker_creds_for_image, image)
+    end
+
+    it "defaults docker_config_creds to true so ~/.docker/config.json is still read" do
+      _(driver[:docker_config_creds]).must_equal true
+    end
+
+    it "uses the Docker Hub entry for an unqualified Hub image" do
+      _(creds_for("dokken/almalinux-8:latest", hub_only)).must_equal hub_creds
+    end
+
+    it "uses the Docker Hub entry for a docker.io-qualified image" do
+      _(creds_for("docker.io/library/almalinux:9", hub_only)).must_equal hub_creds
+    end
+
+    it "sends no credentials to another registry when only Docker Hub is configured" do
+      _(creds_for("quay.io/almalinuxorg/almalinux:10", hub_only)).must_equal({})
+    end
+
+    # docker-api treats a nil creds argument as "use the process-global
+    # ::Docker.creds", which authenticate! populates from creds_file. Returning
+    # an empty hash is what actually makes the pull anonymous.
+    it "never returns nil, which docker-api would resolve to the global creds" do
+      _(creds_for("quay.io/almalinuxorg/almalinux:10", hub_only)).wont_be_nil
+    end
+
+    it "uses the matching entry when the image's registry is configured" do
+      _(creds_for("quay.io/almalinuxorg/almalinux:10", hub_only.merge("quay.io" => quay_creds))).must_equal quay_creds
+    end
+
+    it "matches a registry entry that was written as a URL" do
+      _(creds_for("quay.io/almalinuxorg/almalinux:10", { "https://quay.io/" => quay_creds })).must_equal quay_creds
+    end
+
+    it "matches a localhost registry with a port" do
+      local = { serveraddress: "localhost:5000", username: "local", password: "local-secret" }
+      _(creds_for("localhost:5000/almalinux:9", { "localhost:5000" => local })).must_equal local
+    end
+
+    it "resolves credential helper entries by calling them" do
+      _(creds_for("quay.io/almalinuxorg/almalinux:10", { "quay.io" => proc { quay_creds } })).must_equal quay_creds
+    end
+
+    it "resolves credential helper entries for Docker Hub images" do
+      _(creds_for("dokken/almalinux-8:latest", { "index.docker.io" => proc { hub_creds } })).must_equal hub_creds
+    end
+
+    it "prefers creds_file over ~/.docker/config.json when it is set" do
+      config[:creds_file] = "/path/to/creds.json"
+      driver.stubs(:docker_creds).returns(quay_creds)
+      _(driver.send(:docker_creds_for_image, "quay.io/almalinuxorg/almalinux:10")).must_equal quay_creds
+    end
+
+    it "skips ~/.docker/config.json entirely when docker_config_creds is false" do
+      config[:docker_config_creds] = false
+      _(creds_for("dokken/almalinux-8:latest", hub_only)).must_equal({})
+    end
+
+    # A stale "docker.io" entry alongside the canonical key must not win just
+    # because it happens to be listed first.
+    it "prefers the canonical Docker Hub key regardless of config.json order" do
+      stale = { serveraddress: "docker.io", username: "stale", password: "stale-secret" }
+      ordered = { "docker.io" => stale, "https://index.docker.io/v1/" => hub_creds }
+      _(creds_for("dokken/almalinux-8:latest", ordered)).must_equal hub_creds
+
+      reversed = { "https://index.docker.io/v1/" => hub_creds, "docker.io" => stale }
+      _(creds_for("dokken/almalinux-8:latest", reversed)).must_equal hub_creds
+    end
+  end
 end


### PR DESCRIPTION
# Description

`docker_creds_for_image` falls back to the Docker Hub entry in `~/.docker/config.json` whenever the image's registry has no exact match in `auths`:

```ruby
if docker_config_creds.key?(image_registry)
  ...
elsif docker_config_creds.key?(default_registry)   # "https://index.docker.io/v1/"
  ...                                              # <- fires for *any* registry
end
```

That fallback is load-bearing for Hub images — `"dokken/almalinux-8".split("/").first` is `"dokken"`, which never matches an `auths` key, so without it Hub auth would not work at all. But it also means a `config.json` containing only a Docker Hub login (the common case, and the only thing `docker login` writes by default) offers those credentials to every other registry.

## Repro

`~/.docker/config.json` holds only a Hub login. Driver image is `quay.io/almalinuxorg/almalinux:10`:

```
Failed to complete #create action: [Docker::Error::UnauthorizedError]
Head "https://quay.io/v2/almalinuxorg/almalinux/manifests/10": unauthorized: Invalid Username or Password
```

Confirmed by replaying the call the driver makes:

```ruby
Docker::Image.create({ "fromImage" => "quay.io/almalinuxorg/almalinux:10" }, hub_creds)
# => Docker::Error::UnauthorizedError: ... unauthorized: Invalid Username or Password
Docker::Image.create({ "fromImage" => "quay.io/almalinuxorg/almalinux:10" }, nil)
# => pulls fine
```

The `docker` CLI handles the identical `config.json` correctly, because it scopes credentials per registry.

## Fix

Decide whether an image reference names a registry the way Docker itself does: the leading path component is a registry only when it contains a `.` or a `:`, or is exactly `localhost`.

- **Registry-qualified** (`quay.io/org/img`, `localhost:5000/img`) → look up only that registry; pull anonymously when it has no entry.
- **Unqualified** (`almalinux:9`, `dokken/almalinux-8`) → resolves to Docker Hub, so it keeps using the `https://index.docker.io/v1/` entry exactly as before.

Registry keys are compared through the existing `parse_registry_host` helper, so `quay.io` and `https://quay.io/` both match, and `docker.io` / `index.docker.io` / `registry-1.docker.io` are all recognized as aliases of Docker Hub. `credHelpers` `Proc` entries are still resolved by calling them, on both paths — the behavior #317 added is preserved and now covered by tests.

"No credentials" is an explicit empty hash, not `nil`. docker-api resolves a `nil` creds argument to the process-global `::Docker.creds`:

```ruby
# docker-api 2.4.0, lib/docker/image.rb:122
credentials = creds.nil? ? Docker.creds : MultiJson.dump(creds)
```

`authenticate!` populates that global from `creds_file` and never clears it, so with `nil` an instance configured with `creds_file` would leak its password to every unrelated registry pulled later in the same `kitchen test` run. Verified against Docker 29.6.2 — with the global populated, `nil` creds gets quay.io a 401 while `{}` pulls anonymously, and `{}` does not break Hub pulls.

When a config spells Docker Hub more than one way, the canonical `https://index.docker.io/v1/` key wins, then a fixed alias order — so the credential chosen never depends on `config.json` key ordering (`main` was deterministic here; an earlier draft of this PR was not).

Credentials are also looked up for the path that is actually pulled (`registry_image_path(image)`) rather than the unqualified image name, so a `docker_registry` mirror is matched against its own `auths` entry instead of falling through to Hub.

### `docker_config_creds`

`default_config :docker_config_creds, false` has been declared since #262 but `config[:docker_config_creds]` is never read anywhere in the gem — the identically named *method* is called unconditionally, so `~/.docker/config.json` is always consumed and the option documented in the README does nothing.

This PR reads it, and **defaults it to `true`** so that today's behavior is preserved for everyone. Setting `docker_config_creds: false` now skips `config.json` entirely, which lets registry-proxy users force anonymous pulls without the workaround of pointing `creds_file` at a file containing `{}`.

Wiring it up with the declared default of `false` was the alternative, but that would silently break every user who relies on Hub auth today (including the case #317 was fixing). Happy to flip it if you'd rather have the strict opt-in and treat it as a breaking change.

## Verification

With a `config.json` holding only a Hub login, on this branch:

```
auths keys: ["https://index.docker.io/v1/"]
  quay.io/almalinuxorg/almalinux:10      -> {} (explicit anonymous)
  dokken/almalinux-8:latest              -> creds for https://index.docker.io/v1/
  docker.io/library/almalinux:9          -> creds for https://index.docker.io/v1/
  almalinux:9                            -> creds for https://index.docker.io/v1/

With ::Docker.creds populated (simulating a creds_file instance in the same run):
  PULLED OK  quay.io/almalinuxorg/almalinux:10
  PULLED OK  dokken/almalinux-8:latest
```

14 new unit tests cover Hub short names, Hub-qualified names, a quay image with Hub-only config, a quay image with a quay entry, URL-style keys, `localhost:5000`, credential helpers on both paths, `creds_file` precedence, `docker_config_creds: false`, that the return value is never `nil`, and that Hub key selection is order-independent.

Tested against kitchen-dokken `main` (2.23.1), docker-api 2.4.0, Docker Engine 29.6.2 (API 1.55), Ruby 3.4.5.

## Prior art

- #262 introduced `docker_config_creds` and the Hub fallback
- #284 restored reading `config.json`
- #287 added credential helper support
- #317 made the Hub fallback resolve `credHelpers` Procs — preserved here

## Type of Change

- `_fix_`

## Check List

- [x] New functionality includes tests
- [x] All tests pass (`bundle exec rake` — chefstyle clean, 34 runs, 0 failures; suite passes with no Docker daemon reachable)
- [x] Commit message includes a [Conventional Commit Message](https://www.conventionalcommits.org/en/v1.0.0)
