### PR TITLE
fix: keep the OCI platform variant so variant platforms work end to end

### DIFF
--- a/lib/kitchen/driver/dokken.rb
+++ b/lib/kitchen/driver/dokken.rb
@@ -16,6 +16,7 @@
 # limitations under the License.
 
 require "digest" unless defined?(Digest)
+require "json" unless defined?(JSON)
 require "kitchen"
 require "tmpdir" unless defined?(Dir.mktmpdir)
 require "docker"
@@ -370,7 +371,7 @@ module Kitchen
           config["HostConfig"]["UsernsMode"] = "host"
         end
 
-        runner_container = run_container(config)
+        runner_container = run_container(config, platform: self[:platform])
         state[:runner_container] = runner_container.json
       end
 
@@ -397,6 +398,12 @@ module Kitchen
             },
           }
         end
+        # Deliberately not pinned to config[:platform]: this container only
+        # serves kitchen's files over ssh, so its architecture is irrelevant to
+        # the system under test. The data image is built locally from
+        # almalinux:9 (see Helpers#create_data_image) and is therefore always
+        # host-architecture -- pinning it fails outright whenever the platform
+        # under test differs from the host.
         data_container = run_container(config)
         state[:data_container] = data_container.json
       end
@@ -443,7 +450,9 @@ module Kitchen
                 "NetworkMode" => self[:network_mode],
               },
             }
-            chef_container = create_container(config)
+            # /opt/chef from this container is mounted into the runner, so it
+            # has to be built for the same architecture as the runner.
+            chef_container = create_container(config, platform: self[:platform])
             state[:chef_container] = chef_container.json
           rescue ::Docker::Error, StandardError => e
             raise "driver - #{chef_container_name} failed to create #{e}"
@@ -596,18 +605,17 @@ module Kitchen
         end
       end
 
-      def create_container(args)
+      def create_container(args, platform: nil)
         with_retries { @container = ::Docker::Container.get(args["name"], {}, docker_connection) }
       rescue
         with_retries do
           args["Env"] = [] if args["Env"].nil?
           args["Env"] << "TEST_KITCHEN=1"
           args["Env"] << "CI=#{ENV["CI"]}" if ENV.include? "CI"
-          args["Platform"] = config[:platform]
           info "Creating container #{args["name"]}"
           debug "driver - create_container args #{args}"
           with_retries do
-            @container = ::Docker::Container.create(args.clone, docker_connection)
+            @container = create_container_for_platform(args.clone, platform)
           rescue ::Docker::Error::ConflictError
             debug "driver - rescue ConflictError: #{args["name"]}"
             with_retries { @container = ::Docker::Container.get(args["name"], {}, docker_connection) }
@@ -618,8 +626,25 @@ module Kitchen
         end
       end
 
-      def run_container(args)
-        create_container(args)
+      # Create a container, optionally pinned to an OCI platform.
+      #
+      # /containers/create takes `platform` as a *query* parameter, but
+      # Docker::Container.create only ever forwards `name` to the query string
+      # and dumps everything else into the request body. A "Platform" body key
+      # is therefore accepted and silently ignored by the daemon, which is why
+      # the platform config had no effect on container creation. Post directly
+      # when a platform is wanted; otherwise use the gem as before.
+      def create_container_for_platform(args, platform)
+        return ::Docker::Container.create(args, docker_connection) if platform.to_s.empty?
+
+        query = { "name" => args["name"], "platform" => platform }
+        body = args.reject { |k, _| k == "name" }
+        docker_connection.post("/containers/create", query, body: JSON.dump(body))
+        ::Docker::Container.get(args["name"], {}, docker_connection)
+      end
+
+      def run_container(args, platform: nil)
+        create_container(args, platform: platform)
         with_retries do
           @container.start
           @container = ::Docker::Container.get(args["name"], {}, docker_connection)
@@ -664,7 +689,7 @@ module Kitchen
 
       def chef_container_name
         prefix = instance.provisioner[:product_name] == "cinc" ? "cinc" : "chef"
-        config[:platform] != "" ? "#{prefix}-#{chef_version}-" + config[:platform].sub("/", "-") : "#{prefix}-#{chef_version}"
+        config[:platform] != "" ? "#{prefix}-#{chef_version}-" + config[:platform].tr("/", "-") : "#{prefix}-#{chef_version}"
       end
 
       def chef_image
@@ -739,12 +764,18 @@ module Kitchen
         end
       end
 
+      # Convert an "os/arch[/variant]" platform string into the JSON OCI
+      # platform spec the Docker API expects as an image filter. The variant
+      # matters: the daemon will not match a filter of
+      # {"os":"linux","architecture":"amd64"} against a linux/amd64/v2 image,
+      # so dropping it makes every image lookup for a variant image miss.
       def oci_platform(platform)
-        if !platform.nil? && platform.include?("/")
-          os, arch = platform.split("/")
-          platform = { os: os, architecture: arch }.to_json
-        end
-        platform
+        return platform if platform.nil? || !platform.include?("/")
+
+        os, architecture, variant = platform.split("/")
+        spec = { os: os, architecture: architecture }
+        spec[:variant] = variant unless variant.nil? || variant.empty?
+        spec.to_json
       end
 
       def runner_container_name

--- a/lib/kitchen/helpers.rb
+++ b/lib/kitchen/helpers.rb
@@ -204,9 +204,7 @@ module Dokken
       else
         x = Array(v).map { |a| parse_port(a) }
         x.flatten!
-        x.each_with_object({}) do |y, h|
-          h[y["container_port"]] = {}
-        end
+        x.to_h { |y| [y["container_port"], {}] }
       end
     end
 

--- a/spec/kitchen/driver/dokken_spec.rb
+++ b/spec/kitchen/driver/dokken_spec.rb
@@ -60,5 +60,132 @@ describe Kitchen::Driver::Dokken do
       config[:platform]                 = "linux/amd64"
       _(driver.send(:chef_container_name)).must_equal "cinc-latest-linux-amd64"
     end
+
+    it "replaces every slash so a variant platform yields a valid container name" do
+      config[:platform] = "linux/amd64/v2"
+      _(driver.send(:chef_container_name)).must_equal "chef-latest-linux-amd64-v2"
+    end
+  end
+
+  describe "#oci_platform" do
+    def oci(platform)
+      driver.send(:oci_platform, platform)
+    end
+
+    it "passes nil through untouched" do
+      _(oci(nil)).must_be_nil
+    end
+
+    it "passes an empty platform through untouched" do
+      _(oci("")).must_equal ""
+    end
+
+    it "passes a bare value with no slash through untouched" do
+      _(oci("linux")).must_equal "linux"
+    end
+
+    it "converts os/arch to an OCI platform spec" do
+      _(JSON.parse(oci("linux/amd64"))).must_equal({ "os" => "linux", "architecture" => "amd64" })
+    end
+
+    it "keeps the variant for linux/amd64/v2" do
+      _(JSON.parse(oci("linux/amd64/v2"))).must_equal(
+        { "os" => "linux", "architecture" => "amd64", "variant" => "v2" }
+      )
+    end
+
+    it "keeps the variant for linux/arm64/v8" do
+      _(JSON.parse(oci("linux/arm64/v8"))).must_equal(
+        { "os" => "linux", "architecture" => "arm64", "variant" => "v8" }
+      )
+    end
+
+    it "omits an empty trailing variant" do
+      _(JSON.parse(oci("linux/amd64/"))).must_equal({ "os" => "linux", "architecture" => "amd64" })
+    end
+  end
+
+  describe "#create_container_for_platform" do
+    let(:args) { { "name" => "dokken-test", "Image" => "almalinux:9", "Cmd" => ["true"] } }
+    let(:connection) { stub("connection") }
+
+    before do
+      driver.stubs(:docker_connection).returns(connection)
+    end
+
+    it "uses Docker::Container.create when no platform is given" do
+      ::Docker::Container.expects(:create).with(args, connection).returns(:container)
+      _(driver.send(:create_container_for_platform, args, nil)).must_equal :container
+    end
+
+    it "uses Docker::Container.create when the platform is empty" do
+      ::Docker::Container.expects(:create).with(args, connection).returns(:container)
+      _(driver.send(:create_container_for_platform, args, "")).must_equal :container
+    end
+
+    it "posts platform as a query parameter, not as a body key" do
+      connection.expects(:post).with(
+        "/containers/create",
+        { "name" => "dokken-test", "platform" => "linux/amd64/v2" },
+        { body: JSON.dump("Image" => "almalinux:9", "Cmd" => ["true"]) }
+      ).returns('{"Id":"deadbeef"}')
+      ::Docker::Container.expects(:get).with("dokken-test", {}, connection).returns(:container)
+
+      _(driver.send(:create_container_for_platform, args, "linux/amd64/v2")).must_equal :container
+    end
+  end
+
+  describe "which containers get pinned to the platform" do
+    before do
+      config[:platform] = "linux/arm64/v8"
+      # start_runner_container reaches calc_volumes_binds -> remote_docker_host?,
+      # which resolves the lazy :docker_info default and issues a live GET /info
+      # against the daemon. Keep the unit suite hermetic.
+      driver.stubs(:remote_docker_host?).returns(false)
+      driver.stubs(:running_inside_docker?).returns(false)
+    end
+
+    it "pins the runner container, whose architecture is under test" do
+      driver.expects(:run_container).with(anything, platform: "linux/arm64/v8").returns(stub(json: {}))
+      driver.send(:start_runner_container, {})
+    end
+
+    it "pins the chef volume container, whose /opt/chef is mounted into the runner" do
+      driver.stubs(:with_file_lock).yields
+      driver.stubs(:docker_connection).returns(stub("connection"))
+      ::Docker::Container.stubs(:all).returns([])
+      driver.expects(:create_container).with(anything, platform: "linux/arm64/v8").returns(stub(json: {}))
+      driver.send(:create_chef_container, {})
+    end
+
+    it "does not pin the data container, which only serves files over ssh" do
+      driver.expects(:run_container).with { |_args, **opts| opts.empty? }.returns(stub(json: {}))
+      driver.send(:start_data_container, {})
+    end
+  end
+
+  describe "platform forwarding through the whole create chain" do
+    let(:connection) { stub("connection") }
+    let(:created)    { stub("container", start: nil) }
+
+    before do
+      driver.stubs(:docker_connection).returns(connection)
+      driver.stubs(:wait_running_state)
+    end
+
+    # Guards the two kwarg hand-offs that the call-site tests above cannot see:
+    # run_container -> create_container -> create_container_for_platform.
+    it "carries the platform from run_container down to the create query" do
+      ::Docker::Container.stubs(:get).raises(::Docker::Error::NotFoundError).then.returns(created)
+      connection.expects(:post).with do |path, query, opts|
+        body = JSON.parse(opts[:body])
+        path == "/containers/create" &&
+          query == { "name" => "runner", "platform" => "linux/arm64/v8" } &&
+          !body.key?("name") &&
+          body["Image"] == "img"
+      end.returns('{"Id":"deadbeef"}')
+
+      driver.send(:run_container, { "name" => "runner", "Image" => "img" }, platform: "linux/arm64/v8")
+    end
   end
 end


### PR DESCRIPTION
# Description

Setting `platform:` in the driver does not work. Three separate problems, with three different blast radii — one of them affects *every* config that sets `platform` at all, variant or not.

| # | Problem | Who it affects |
| --- | --- | --- |
| 1 | `oci_platform` drops the variant from image lookups | `linux/amd64/v2`, `/v3`, `/v4` |
| 2 | `sub("/", "-")` leaves a slash in container names | every three-component platform: `linux/arm/v6`, `linux/arm/v7`, `linux/arm64/v8`, `linux/amd64/v2..v4` |
| 3 | `Platform` on container create is silently ignored | **every** `platform:` value, including plain `linux/amd64` and `linux/arm64` |

## 1. `oci_platform` drops the variant

```ruby
os, arch = platform.split("/")          # "linux/amd64/v2" loses "v2"
platform = { os: os, architecture: arch }.to_json
```

Every `Docker::Image.exist?` / `Docker::Image.get` in the driver passes that filter (`delete_work_image`, `build_work_image`, `delete_image`, `pull_if_missing`, `pull_image`). Against Docker 29.6.2 (API 1.55) with a local `amd64/v2` image:

```
GET /images/<img>/json                                                 -> 200
GET ...?platform={"os":"linux","architecture":"amd64"}                 -> 404
GET ...?platform={"os":"linux","architecture":"amd64","variant":"v2"}  -> 200
```

So `pull_if_missing` never saw a local variant image and re-pulled on every run, and the `Image.get` calls raised 404 even immediately after a successful pull.

This one is specific to the **x86-64 microarchitecture levels**, because an amd64 request with no variant means the v1 baseline and the daemon matches a level only against images at or below it:

| request | vs `amd64/v2` image |
| --- | --- |
| `amd64` (no variant) | **404** |
| `amd64` + `variant: v1` | **404** |
| `amd64` + `variant: v2` | 200 |
| `amd64` + `variant: v3` | 200 |
| `amd64` + `variant: v4` | 200 |

That makes every `amd64/v2`, `/v3` and `/v4` image invisible to the current filter — the direction RHEL 10, AlmaLinux 10 and the rest of the `x86-64-v2`/`v3` rebuilds are moving in.

Measured for comparison, arm is *not* affected by this one — a bare `arm`/`arm64` request matches its variants:

```
linux/arm/v6     bare {os,arch} filter: 200   with variant: 200
linux/arm/v7     bare {os,arch} filter: 200   with variant: 200
linux/arm64/v8   bare {os,arch} filter: 200   with variant: 200
```

Including the variant is therefore strictly safer than omitting it: it is required for the amd64 levels and harmless everywhere else. It is also safe for the images dokken pulls with the same platform string — an `amd64/v2` filter still matches a plain-`amd64` image such as `cincproject/cinc`.

## 2. Container and volume names keep a slash

```ruby
config[:platform].sub("/", "-")   # only the first slash
```

`linux/arm64/v8` becomes `chef-latest-linux-arm64/v8`, which is not a valid docker name. It actually fails earlier than that, in `with_file_lock`:

```
$ kitchen create   # platform: linux/arm64/v8, on main
Failed to complete #create action:
[No such file or directory @ rb_sysopen - /home/lance/.dokken-cinc-latest-linux-arm64/v8.lock]
```

Identical failure for `linux/amd64/v2`. This hits **every** three-component platform, which is to say every value anyone copies out of `docker manifest inspect` or `docker buildx imagetools inspect` — both print `linux/arm/v7` and `linux/arm64/v8` in exactly that form. Changed to `tr("/", "-")`.

## 3. `Platform` on container create is silently ignored

`create_container` set `args["Platform"] = config[:platform]`, but `/containers/create` takes `platform` as a **query parameter**, and `Docker::Container.create` only ever forwards `name` to the query string:

```ruby
# docker-api 2.4.0, lib/docker/container.rb
def self.create(opts = {}, conn = Docker.connection)
  query = opts.select {|key| ['name', :name].include?(key) }
  clean_opts = opts.reject {|key| ['name', :name].include?(key) }
  resp = conn.post('/containers/create', query, :body => MultiJson.dump(clean_opts))
```

Everything else lands in the body, where the daemon accepts and ignores it. Probing Docker 29.6.2 with a deliberately invalid value:

```
POST /containers/create?name=a   body {"Image":"almalinux:9","Platform":"nonsense/nonsense"}  -> 201 Created
POST /containers/create?name=b&platform=nonsense/nonsense   body {"Image":"almalinux:9"}      -> 404
POST /containers/create?name=c&platform=linux/amd64/v2      body {...almalinux:10 v2...}      -> 201 Created
```

**This one has nothing to do with variants** — `platform: linux/amd64` has never had any effect on the containers dokken creates either. It only appeared to work when the local tag already happened to point at the right architecture, which is exactly what stops being true with the containerd image store, where one tag can hold several platforms at once. This is #288 and #356.

Fixed by posting directly with the query parameter **only when a platform is wanted**; with no platform the code path is `Docker::Container.create` exactly as before. Error mapping is unaffected — `Docker::Connection#request` is what translates Excon errors into `Docker::Error::ConflictError` / `NotFoundError`, and that sits below the call.

Only the containers whose architecture has to match the system under test are pinned: the runner, and the chef/cinc volume container whose `/opt/chef` is mounted into it. The data container just serves kitchen's files over ssh, so its architecture is irrelevant to the system under test. Its image is built locally from `almalinux:9` (`Helpers#create_data_image`) and is therefore always host-architecture — pinning it breaks every cross-architecture run on a remote or in-docker host:

```
image with reference dokken/kitchen-cache:latest was found but its platform
(linux/amd64) does not match the specified platform (linux/arm64/v8)
```

## Verification

**`linux/arm64/v8`**, emulated on an amd64 host, `image: dokken/almalinux-9`:

```
-----> Creating <variant-almalinux-9-arm64v8>...
       Creating container cinc-latest-linux-arm64-v8
       Creating container ae9e513186-variant-almalinux-9-arm64v8-data
       Building work image..
       Creating container ae9e513186-variant-almalinux-9-arm64v8
       Finished creating <variant-almalinux-9-arm64v8> (0m1.90s).

$ docker exec ae9e513186-variant-almalinux-9-arm64v8 sh -c 'uname -m; cat /etc/almalinux-release'
aarch64
AlmaLinux release 9.8 (Olive Jaguar)
```

The runner and the `cinc-latest-linux-arm64-v8` volume container are arm64; the data container stayed on the host-architecture (amd64) `dokken/kitchen-cache`. On `main` the same config dies at the lock path shown above.

**`linux/amd64/v2`**, `image: quay.io/almalinuxorg/almalinux:10`, nothing pre-pulled:

```
$ docker image inspect quay.io/almalinuxorg/almalinux:10 --format '{{.Os}}/{{.Architecture}}/{{.Variant}}'
linux/amd64/v2
$ docker image inspect ae9e513186-variant-almalinux-10-v2 --format '{{.Os}}/{{.Architecture}}/{{.Variant}}'
linux/amd64/v2
$ docker exec ae9e513186-variant-almalinux-10-v2 sh -c 'uname -m; cat /etc/almalinux-release'
x86_64
AlmaLinux release 10.2 (Lavender Lion)
```

With `pull_platform_image: false` and the image already local, a second `kitchen create` produces zero pull activity — the local-image check matches instead of forcing an unconditional re-pull.

**No platform set:** `kitchen create default-almalinux-9` against `kitchen.cinc.yml` still creates `cinc-latest` and converges normally.

Tested against kitchen-dokken `main` (2.23.1), docker-api 2.4.0, Docker Engine 29.6.2 (API 1.55), Ruby 3.4.5. 15 new unit tests cover `oci_platform` for `nil` / `""` / no-slash / `linux/amd64` / `linux/amd64/v2` / `linux/arm64/v8` / trailing-empty-variant, the container name, the query-parameter posting, which containers get pinned, and one test that drives the whole `run_container -> create_container -> create_container_for_platform` chain. Mutation-checked: dropping the `platform:` kwarg at any of the three hand-offs, or wrongly pinning the data container, each fails the suite.

## Drive-by: unrelated lint fix in `lib/kitchen/helpers.rb`

The second commit is **not** part of the platform fix. cookstyle 8.7.6 enables `Style/ReduceToHash`, which flags an `each_with_object({})` in `coerce_exposed_ports`. Because the shared lint workflow installs cookstyle fresh instead of from `Gemfile.lock` (which still pins 8.6.10, a version without the cop), the lint job now fails on **every** PR opened against `main` — I reproduced the identical single offense against a pristine `main` worktree with 8.7.6. Since `Unit Test with Ruby` is gated on `needs: lint`, that also skips all three unit legs.

Folding the one-line fix in here so this PR can go green. Happy to split it into its own PR if you'd rather keep this one single-purpose — and the underlying mismatch (CI floating vs. a pinned lockfile) is worth addressing separately.

## Related

- Fixes #288 — `platform: linux/amd64` ignored, container shows aarch64
- Fixes #356 — unable to run `linux/amd64` containers on an m4 mac
- #357 introduced `oci_platform`
- #364 guards the same line with `unless config[:platform].empty?`. That is a no-op in practice: the body key was ignored whether it held `""` or `"linux/amd64"`, so it does not fix #288 or #356. I'd suggest closing it in favour of this, but happy to move the change there instead if you'd prefer.
- #361 — earlier attempt at the same area

## Type of Change

- `_fix_`

## Check List

- [x] New functionality includes tests
- [x] All tests pass (`bundle exec rake` — chefstyle clean, 31 runs, 0 failures; suite passes with no Docker daemon reachable)
- [x] Commit message includes a [Conventional Commit Message](https://www.conventionalcommits.org/en/v1.0.0)
